### PR TITLE
fix: fix #58bug

### DIFF
--- a/apps/client/components/main/Question.vue
+++ b/apps/client/components/main/Question.vue
@@ -10,16 +10,8 @@
           {{ userInputWords[i - 1] }}
         </div>
       </template>
-      <input
-        ref="inputEl"
-        class="absolute h-full w-full opacity-0"
-        type="text"
-        v-model="inputValue"
-        @keyup="handleKeyup"
-        @focus="handleInputFocus"
-        @blur="handleBlur"
-        autoFocus
-      />
+      <input ref="inputEl" class="absolute h-full w-full opacity-0" type="text" v-model="inputValue" @keyup="handleKeyup"
+        @focus="handleInputFocus" @blur="handleBlur" autoFocus />
     </div>
     <div class="mt-12 text-xl dark:text-gray-50">
       {{ courseStore.currentStatement?.chinese || '生存还是毁灭，这是一个问题' }}
@@ -35,6 +27,21 @@ const courseStore = useCourseStore();
 const { userInputWords, activeInputIndex, inputValue } = useInput();
 const { handleKeyup } = registerShortcutKeyForInputEl();
 const { inputEl, focusing, handleInputFocus, handleBlur } = useFocus();
+
+// 监听 shouldRestoreCursor 状态，决定是否恢复光标位置
+watch(() => courseStore.shouldRestoreCursor, (shouldRestore) => {
+  if (shouldRestore) {
+    nextTick(() => {
+      const position = courseStore.cursorPosition;
+      if (inputEl.value && typeof position === 'number') {
+        inputEl.value.setSelectionRange(position, position);
+        inputEl.value.focus();
+        // 恢复后，重置标志
+        courseStore.resetCursorRestore();
+      }
+    });
+  }
+});
 
 function useInput() {
   const inputValue = ref('');

--- a/apps/client/store/course.ts
+++ b/apps/client/store/course.ts
@@ -19,6 +19,10 @@ export const useCourseStore = defineStore("course", () => {
   const currentCourse = ref<Course>();
   const statementIndex = ref(0);
   const currentStatement = ref<Statement>();
+  // 新增状态：用于保存当前文本框中的光标位置
+  const cursorPosition = ref<number | null>(null);
+  // 新增状态：标志是否需要恢复光标位置
+  const shouldRestoreCursor = ref(false);
 
   const { saveProgress, loadProgress, cleanProgress } = useCourseProgress();
 
@@ -54,7 +58,7 @@ export const useCourseStore = defineStore("course", () => {
   }
 
   function doAgain() {
-    resetStatementIndex()
+    resetStatementIndex();
   }
 
   function checkCorrect(input: string) {
@@ -66,7 +70,7 @@ export const useCourseStore = defineStore("course", () => {
 
   async function completeCourse(cId: number) {
     const nextCourse = await fetchCompleteCourse(cId);
-    resetStatementIndex()
+    resetStatementIndex();
     return nextCourse;
   }
 
@@ -76,9 +80,20 @@ export const useCourseStore = defineStore("course", () => {
     statementIndex.value = loadProgress(courseId);
   }
 
-
-  function resetStatementIndex () {
-    statementIndex.value = 0
+  function resetStatementIndex() {
+    statementIndex.value = 0;
+  }
+// 新增方法：保存光标位置
+  function saveCursorPosition(position: number) {
+    cursorPosition.value = position;
+  }
+// 新增方法：触发光标位置恢复的标志
+  function triggerCursorRestore() {
+    shouldRestoreCursor.value = true;
+  }
+// 新增方法：重置光标位置恢复的标志
+  function resetCursorRestore() {
+    shouldRestoreCursor.value = false;
   }
 
   return {
@@ -94,7 +109,12 @@ export const useCourseStore = defineStore("course", () => {
     completeCourse,
     toNextStatement,
     cleanProgress,
-    resetStatementIndex
+    resetStatementIndex,
+    cursorPosition,
+    shouldRestoreCursor,
+    saveCursorPosition,
+    triggerCursorRestore,
+    resetCursorRestore,
   };
 });
 


### PR DESCRIPTION
问题描述:
本次 PR 解决了用户在输入框中输入单词后，按下 Ctrl+P 触发声音播放时光标跳转到输入框开头的问题

更改说明：
- 在 `course.ts` 中添加了 `cursorPosition` 和 `shouldRestoreCursor` 状态，用于保存和指示是否需要恢复光标位置
- 在 `Question.vue` 中添加了一个 `watch` 监听器，监听 `shouldRestoreCursor` 状态。当该状态为 `true` 时，将光标位置恢复到 `cursorPosition` 所保存的位置，并重新聚焦输入框
- 修改了 `Tips.vue` 中的 `handlePlaySound` 方法，以在播放声音前保存光标位置，并在声音播放后恢复光标位置