### PR TITLE
fix(Question): prevent multiple spaces from being entered #93

### DIFF
--- a/apps/client/components/main/Question.vue
+++ b/apps/client/components/main/Question.vue
@@ -16,6 +16,7 @@
         type="text"
         v-model="inputValue"
         @keyup="handleKeyup"
+        @keydown="handleKeydown"
         @focus="handleInputFocus"
         @blur="handleBlur"
         autoFocus
@@ -33,7 +34,7 @@ import { useGameMode } from '~/composables/main/game';
 
 const courseStore = useCourseStore();
 const { userInputWords, activeInputIndex, inputValue } = useInput();
-const { handleKeyup } = registerShortcutKeyForInputEl();
+const { handleKeyup, handleKeydown } = registerShortcutKeyForInputEl();
 const { inputEl, focusing, handleInputFocus, handleBlur } = useFocus();
 
 function useInput() {
@@ -68,8 +69,22 @@ function registerShortcutKeyForInputEl() {
     }
   }
 
+  function handleKeydown(e: KeyboardEvent) {
+    const inputLastStr = inputValue.value[inputValue.value.length - 1]
+    if (e.code === 'Space' && inputLastStr === ' ') {
+      // prevent input multiple spaces
+      e.preventDefault()
+    }
+    if (e.code === 'Backspace' && userInputWords.value.length - courseStore.wordCount === 1 && inputLastStr === ' ') {
+      // remove the last space and the last letter
+      e.preventDefault()
+      inputValue.value = inputValue.value.slice(0, -2)
+    }
+  }
+
   return {
     handleKeyup,
+    handleKeydown
   };
 }
 


### PR DESCRIPTION
1. 限制只能键入一个空格，防止仅有一个单词或者最后一个单词时输入一个以上空格后继续输入，前端不正常显示的问题。
2. 在仅有一个单词或光标在最后一个单词的后面有一个空格时，按一次退格键即可正常删除最后一个字母，而不是两次
related to #93 