### PR TITLE
feat: Incorrect title added to the sentence that follows it #77

### DIFF
--- a/apps/client/components/main/Question.vue
+++ b/apps/client/components/main/Question.vue
@@ -70,6 +70,8 @@ function registerShortcutKeyForInputEl() {
 
       if (courseStore.checkCorrect(inputValue.value.trim())) {
         showAnswer();
+      } else if (courseStore.currentStatement && !courseStore.currentStatement.incorrectQuestionId) {
+        courseStore.updateIncorrectQuestions()
       }
       inputValue.value = "";
     }

--- a/apps/client/components/main/Summary.vue
+++ b/apps/client/components/main/Summary.vue
@@ -81,6 +81,7 @@ function useDoAgain() {
 
   function handleDoAgain() {
     courseStore.doAgain();
+    courseStore.currentCourse?.id && courseStore.resetCurrentCourse(courseStore.currentCourse?.id)
     hideSummary();
     showQuestion();
   }
@@ -121,6 +122,7 @@ function useGoToNextCourse() {
   async function handleGoToNextCourse() {
     // 无论后续如何处理，都需要先隐藏 Summary 页面
     hideSummary()
+    courseStore.currentCourse?.id && courseStore.resetCurrentCourse(courseStore.currentCourse?.id)
     if (!userStore.user) {
       // 去注册
       showAuthRequireModal();


### PR DESCRIPTION
关联 issue #77 

### 实现思路

- 具体实现参考的多邻国的功能
- 当某一题目第一次输入错误后，题目会通过`push` 添加到当前课程末尾，课程进度随之延长，同一课程的同一题目多次输入错误只会添加一次；

#### 错题添加：

- 在 `Question.vue` 的 `handleKeyup` 中当回车事件后校验答案错误，然后就将当前题目复制到`currentIncorrectQuestion` 并且设置新的 `id` ，并将原有 `id` 赋值给`incorrectQuestionId` 字段，用于在下次输入错误时校验当前题目是否已经在错题数组中；
- 将处理后的 `currentIncorrectQuestion` 添加到  `courseStore.currentCourse?.statements` 中，并将其缓存在 `localStorage`的 `courseIncorrectQuestion` 中 ；
- 在 `course.ts` 中添加 `useIncorrectQuestion` 用于处理错题的添加、删除、获取，在 `setUp` 时调用 `loadIncorrectQuestion` 获取到缓存的错题，然后与接口返回的数据合并（解决页面刷新后错题回显）；

#### 错题清空：

- 在结算页点击 `再来一次` 或者 `开始下一课` 时调用 `resetCurrentCourse` 清空缓存的错题数据；