### PR TITLE
重构注册登录页：移除naive-ui，采用tailwind和vee-validate

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -33,6 +33,8 @@
     "@types/canvas-confetti": "^1.6.4",
     "axios": "^1.6.6",
     "canvas-confetti": "^1.9.2",
-    "pinia": "^2.1.7"
+    "pinia": "^2.1.7",
+    "vee-validate": "^4.12.5",
+    "yup": "^1.3.3"
   }
 }

--- a/apps/client/pages/Auth/Login.vue
+++ b/apps/client/pages/Auth/Login.vue
@@ -1,46 +1,41 @@
 <template>
-  <div
-    className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8"
-  >
+  <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
     <div className="sm:mx-auto sm:w-full sm:max-w-sm">
       <img className="mx-auto h-10 w-auto" src="/logo.png" alt="earthworm" />
-      <h2
-        className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300"
-      >
+      <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300">
         Log in to your account
       </h2>
     </div>
 
     <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <n-form ref="formEl" :rules="rules" :model="model">
-        <n-form-item path="phone" label="Phone" required>
-          <n-input v-model:value="model.phone" @keydown.enter.prevent @keyup.enter="handleLogin"/>
-        </n-form-item>
-        <n-form-item path="password" label="Password" required>
-          <n-input
-            v-model:value="model.password"
-            type="password"
-            @keydown.enter.prevent
-            @keyup.enter="handleLogin"
-          />
-        </n-form-item>
-        <n-button
-          type="primary"
-          size="large"
-          block
-          @click="handleLogin"
-          class="mt-2"
-        >
-          Log in
-        </n-button>
-      </n-form>
-
+      <form @submit.prevent="handleLogin" class="space-y-6" novalidate>
+        <div>
+          <label for="phone" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">Phone <span
+              class="text-red-500">*</span></label>
+          <input v-model="phone" id="phone" name="phone" type="tel" required placeholder="Please enter your phone number"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+            autocomplete="off">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.phone }}</p>
+        </div>
+        <div>
+          <label for="password" class="block mt-4 text-sm font-medium text-gray-700 dark:text-gray-300">Password <span
+              class="text-red-500">*</span></label>
+          <input v-model="password" id="password" name="password" type="password" required
+            placeholder="Please enter your password"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.password }}</p>
+        </div>
+        <div class="pt-2">
+          <button type="submit"
+            class="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Log in
+          </button>
+        </div>
+      </form>
       <p className="mt-10 text-center text-sm text-gray-500">
         Not an account?
-        <NuxtLink
-          href="/auth/signup"
-          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400"
-        >
+        <NuxtLink href="/auth/signup"
+          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400">
           Sign up
         </NuxtLink>
       </p>
@@ -48,62 +43,34 @@
   </div>
 </template>
 <script setup lang="ts">
-import { type FormInst, type FormRules } from "naive-ui";
+import { useForm, useField } from 'vee-validate';
+import * as yup from 'yup';
 import { useAuth } from "~/composables/auth";
-import { ref } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { useMessage } from "naive-ui";
+import { useRouter, useRoute } from 'vue-router';
 
-interface ModelType {
-  phone: string | null;
-  password: string | null;
-}
-
-const { login } = useAuth();
-
-const formEl = ref<FormInst | null>(null);
-const model = ref<ModelType>({
-  phone: null,
-  password: null,
+const schema = yup.object({
+  phone: yup.string().required("请输入您的手机号码").matches(/^1[3456789]\d{9}$/, "请输入正确的手机号码"),
+  password: yup.string().required("请输入您的密码").min(6, "密码长度必须大于6"),
 });
 
-const rules: FormRules = {
-  phone: [
-    { required: true, message: "Please input your phone number" },
-    {
-      pattern: /^1[3456789]\d{9}$/,
-      message: "Please input correct phone number",
-    },
-  ],
-  password: [
-    { required: true, message: "Please input your password" },
-    { min: 6, message: "Password length must be greater than 6" },
-  ],
-};
+const { handleSubmit, errors } = useForm({
+  validationSchema: schema,
+});
 
-const message = useMessage();
+const { value: phone } = useField('phone');
+const { value: password } = useField('password');
+
 const router = useRouter();
 const route = useRoute();
+const { login } = useAuth();
 
-const handleLogin = () => {
-  function gotoPreviousPage() {
-    router.replace(route.query.callback?.toString() ?? "/");
+const handleLogin = handleSubmit(async (values) => {
+  try {
+    await login(values as { phone: string; password: string; });
+    router.replace(route.query.callback?.toString() || '/');
+  } catch (error) {
+    
   }
+});
 
-  formEl.value?.validate(async (errors) => {
-    if (!errors) {
-      await login({
-        phone: model.value.phone ?? "",
-        password: model.value.password ?? "",
-      });
-
-      message.success("login success", {
-        duration: 500,
-        onLeave() {
-          gotoPreviousPage();
-        },
-      });
-    }
-  });
-};
 </script>

--- a/apps/client/pages/Auth/SignUp.vue
+++ b/apps/client/pages/Auth/SignUp.vue
@@ -1,57 +1,58 @@
 <template>
-  <div
-    className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8"
-  >
+  <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
     <div className="sm:mx-auto sm:w-full sm:max-w-sm">
       <img className="mx-auto h-10 w-auto" src="/logo.png" alt="earthworm" />
-      <h2
-        className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300"
-      >
+      <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300">
         Sign up to your account
       </h2>
     </div>
 
     <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <n-form ref="formEl" :rules="rules" :model="model">
-        <n-form-item path="name" label="Name" required>
-          <n-input v-model:value="model.name" @keydown.enter.prevent @keyup.enter="handleRegister"/>
-        </n-form-item>
-        <n-form-item path="phone" label="Phone" required>
-          <n-input v-model:value="model.phone" @keydown.enter.prevent @keyup.enter="handleRegister"/>
-        </n-form-item>
-        <n-form-item path="password" label="Password" required>
-          <n-input
-            v-model:value="model.password"
-            type="password"
-            @keydown.enter.prevent
-            @keyup.enter="handleRegister"
-          />
-        </n-form-item>
-        <n-form-item path="confirmPassword" label="ConfirmPassword" required>
-          <n-input
-            v-model:value="model.confirmPassword"
-            type="password"
-            @keydown.enter.prevent
-            @keyup.enter="handleRegister"
-          />
-        </n-form-item>
-        <n-button
-          type="primary"
-          size="large"
-          block
-          @click="handleRegister"
-          class="mt-2"
-        >
-          Sign in
-        </n-button>
-      </n-form>
-
+      <form @submit.prevent="handleRegister" class="space-y-6" novalidate>
+        <div>
+          <label for="name" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">Name <span
+              class="text-red-500">*</span></label>
+          <input v-model="name" id="name" name="name" type="text" required placeholder="Your name"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+            autocomplete="off">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.name }}</p>
+        </div>
+        <div>
+          <label for="phone" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">Phone <span
+              class="text-red-500">*</span></label>
+          <input v-model="phone" id="phone" name="phone" type="tel" required placeholder="Your phone number"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+            autocomplete="off">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.phone }}</p>
+        </div>
+        <div>
+          <label for="password" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">Password <span
+              class="text-red-500">*</span></label>
+          <input v-model="password" id="password" name="password" type="password" required placeholder="Your password"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+            autocomplete="off">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.password }}</p>
+        </div>
+        <div>
+          <label for="confirmPassword" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">Confirm
+            Password <span class="text-red-500">*</span></label>
+          <input v-model="confirmPassword" id="confirmPassword" name="confirmPassword" type="password" required
+            placeholder="Confirm your password"
+            class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+            autocomplete="off">
+          <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errors.confirmPassword }}</p>
+        </div>
+        <div class="pt-2">
+          <button type="submit"
+            class="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Sign up
+          </button>
+        </div>
+      </form>
       <p className="mt-10 text-center text-sm text-gray-500 dark:text-gray-400">
         Has an account?
-        <NuxtLink
-          href="/auth/login"
-          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400"
-        >
+        <NuxtLink href="/auth/login"
+          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400">
           Log in
         </NuxtLink>
       </p>
@@ -59,77 +60,44 @@
   </div>
 </template>
 <script setup lang="ts">
-import { type FormInst, type FormRules, type FormItemRule } from "naive-ui";
+import { useForm, useField } from 'vee-validate';
+import * as yup from 'yup';
 import { useAuth } from "~/composables/auth";
-import { ref } from "vue";
-import { useRouter } from "vue-router";
-import { useMessage } from "naive-ui";
+import { useRouter } from 'vue-router';
 
-interface ModelType {
-  name: string | null;
-  phone: string | null;
-  password: string | null;
-  confirmPassword: string | null;
-}
-
-const { signup } = useAuth();
-const formEl = ref<FormInst | null>(null);
-
-const model = ref<ModelType>({
-  name: null,
-  phone: null,
-  password: null,
-  confirmPassword: null,
+const schema = yup.object({
+  name: yup.string().required("Please enter your name").min(2, "Name must be at least 2 characters").max(20, "Name must be less than 20 characters"),
+  phone: yup.string().required("Please enter your phone number").matches(/^1[3456789]\d{9}$/, "Please enter a valid phone number"),
+  password: yup.string().required("Please enter your password").min(6, "Password must be at least 6 characters"),
+  confirmPassword: yup.string().required("Please confirm your password").oneOf([yup.ref('password')], "Passwords must match"),
 });
 
-function validatePasswordSame(rule: FormItemRule, value: string): boolean {
-  return value === model.value.password;
-}
+const { handleSubmit, errors } = useForm({
+  validationSchema: schema,
+});
 
-const rules: FormRules = {
-  name: [
-    { required: true, message: "Please input you name" },
-    { min: 2, max: 20, message: "name length must be min 2 and max 20" },
-  ],
-  phone: [
-    { required: true, message: "Please input your phone number" },
-    {
-      pattern: /^1[3456789]\d{9}$/,
-      message: "Please input correct phone number",
-    },
-  ],
-  password: [
-    { required: true, message: "Please input your password" },
-    { min: 6, max: 20, message: "Password length must be greater than 6" },
-  ],
-  confirmPassword: [
-    { required: true, message: "Please input confirmPassword" },
-    {
-      validator: validatePasswordSame,
-      message: "The two password inputs are inconsistent",
-    },
-  ],
-};
+const { value: name } = useField('name');
+const { value: phone } = useField('phone');
+const { value: password } = useField('password');
+const { value: confirmPassword } = useField('confirmPassword');
 
-const message = useMessage();
 const router = useRouter();
+const { signup } = useAuth();
 
-const handleRegister = () => {
-  formEl.value?.validate(async (errors) => {
-    if (!errors) {
-      await signup({
-        phone: model.value.phone ?? "",
-        name: model.value.name ?? "",
-        password: model.value.password ?? "",
-      });
+const handleRegister = handleSubmit(async (values) => {
+  try {
+    const signupValues = {
+      phone: values.phone as string,
+      name: values.name as string,
+      password: values.password as string,
+    };
+    await signup(signupValues);
+    router.replace("/");
+  } catch (error) {
+    
+  }
+});
 
-      message.success("register success", {
-        duration: 500,
-        onLeave() {
-          router.replace("/");
-        },
-      });
-    }
-  });
-};
 </script>
+
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,13 @@ importers:
         version: 1.9.2
       pinia:
         specifier: ^2.1.7
-        version: 2.1.7(vue@3.4.15)
+        version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
+      vee-validate:
+        specifier: ^4.12.5
+        version: 4.12.5(vue@3.4.15)
+      yup:
+        specifier: ^1.3.3
+        version: 1.3.3
     devDependencies:
       '@bg-dev/nuxt-naiveui':
         specifier: ^1.9.0
@@ -205,7 +211,7 @@ importers:
         version: 2.37.3(vue@3.4.15)
       nuxt:
         specifier: ^3.9.0
-        version: 3.9.3(vite@5.0.12)
+        version: 3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vite@5.0.12)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
@@ -214,10 +220,10 @@ importers:
         version: 0.0.3
       vitest:
         specifier: ^1.2.1
-        version: 1.2.1(happy-dom@13.3.1)
+        version: 1.2.1(@types/node@20.11.0)(happy-dom@13.3.1)
       vue:
         specifier: ^3.4.6
-        version: 3.4.15
+        version: 3.4.15(typescript@5.3.3)
       vue-router:
         specifier: ^4.2.5
         version: 4.2.5(vue@3.4.15)
@@ -775,7 +781,7 @@ packages:
     peerDependencies:
       vue: ^3.0.11
     dependencies:
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@csstools/cascade-layer-name-parser@1.0.7(@csstools/css-parser-algorithms@2.5.0)(@csstools/css-tokenizer@2.2.3):
@@ -1328,7 +1334,7 @@ packages:
       vue: '>=3'
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@img/sharp-darwin-arm64@0.33.2:
@@ -2305,8 +2311,8 @@ packages:
       '@nuxt/kit': 3.9.3
       '@nuxt/schema': 3.9.3
       execa: 7.2.0
-      nuxt: 3.9.3(vite@5.0.12)
-      vite: 5.0.12
+      nuxt: 3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vite@5.0.12)
+      vite: 5.0.12(@types/node@20.11.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -2353,7 +2359,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.3
-      nuxt: 3.9.3(vite@5.0.12)
+      nuxt: 3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vite@5.0.12)
       nypm: 0.3.4
       ohash: 1.1.3
       pacote: 17.0.6
@@ -2366,7 +2372,7 @@ packages:
       simple-git: 3.22.0
       sirv: 2.0.4
       unimport: 3.7.1(rollup@4.9.4)
-      vite: 5.0.12
+      vite: 5.0.12(@types/node@20.11.0)
       vite-plugin-inspect: 0.8.1(@nuxt/kit@3.9.3)(vite@5.0.12)
       vite-plugin-vue-inspector: 4.0.2(vite@5.0.12)
       which: 3.0.1
@@ -2592,10 +2598,10 @@ packages:
       ufo: 1.3.2
       unenv: 1.9.0
       unplugin: 1.6.0
-      vite: 5.0.12
-      vitest: 1.2.1(happy-dom@13.3.1)
+      vite: 5.0.12(@types/node@20.11.0)
+      vitest: 1.2.1(@types/node@20.11.0)(happy-dom@13.3.1)
       vitest-environment-nuxt: 1.0.0(@vue/test-utils@2.4.3)(h3@1.10.0)(happy-dom@13.3.1)(vite@5.0.12)(vitest@1.2.1)(vue-router@4.2.5)(vue@3.4.15)
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
       vue-router: 4.2.5(vue@3.4.15)
     transitivePeerDependencies:
       - rollup
@@ -2605,7 +2611,7 @@ packages:
   /@nuxt/ui-templates@1.3.1:
     resolution: {integrity: sha512-5gc02Pu1HycOVUWJ8aYsWeeXcSTPe8iX8+KIrhyEtEoOSkY0eMBuo0ssljB8wALuEmepv31DlYe5gpiRwkjESA==}
 
-  /@nuxt/vite-builder@3.9.3(vue@3.4.15):
+  /@nuxt/vite-builder@3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vue@3.4.15):
     resolution: {integrity: sha512-HruOrxn0g6TS31j3jycJvGZ7pt3JNEbcXNByVh7YJwQx6ToFX8kPWRu4LPeMhrLYvZzeUr2w3iELBECFxbDmvw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -2640,10 +2646,10 @@ packages:
       strip-literal: 2.0.0
       ufo: 1.3.2
       unplugin: 1.6.0
-      vite: 5.0.11
-      vite-node: 1.2.1
-      vite-plugin-checker: 0.6.2(vite@5.0.11)
-      vue: 3.4.15
+      vite: 5.0.11(@types/node@20.11.0)
+      vite-node: 1.2.1(@types/node@20.11.0)
+      vite-plugin-checker: 0.6.2(typescript@5.3.3)(vite@5.0.11)
+      vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -2850,7 +2856,7 @@ packages:
     peerDependencies:
       pinia: '>=2.1.5'
     dependencies:
-      pinia: 2.1.7(vue@3.4.15)
+      pinia: 2.1.7(typescript@5.3.3)(vue@3.4.15)
       vue-demi: 0.14.6(vue@3.4.15)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -3633,7 +3639,7 @@ packages:
       '@unhead/shared': 1.8.10
       hookable: 5.5.3
       unhead: 1.8.10
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@vercel/nft@0.24.4:
@@ -3667,8 +3673,8 @@ packages:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.7)
       '@vue/babel-plugin-jsx': 1.2.0(@babel/core@7.23.7)
-      vite: 5.0.11
-      vue: 3.4.15
+      vite: 5.0.11(@types/node@20.11.0)
+      vue: 3.4.15(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3680,8 +3686,8 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.11
-      vue: 3.4.15
+      vite: 5.0.11(@types/node@20.11.0)
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@vitest/expect@1.2.1:
@@ -3738,7 +3744,7 @@ packages:
       ast-kit: 0.11.3
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -3846,7 +3852,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.15
       '@vue/shared': 3.4.15
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
 
   /@vue/shared@3.4.15:
     resolution: {integrity: sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==}
@@ -3861,7 +3867,7 @@ packages:
         optional: true
     dependencies:
       js-beautify: 1.14.11
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
       vue-component-type-helpers: 1.8.27
     dev: true
 
@@ -3890,7 +3896,7 @@ packages:
       '@vueuse/core': 10.7.2(vue@3.4.15)
       '@vueuse/metadata': 10.7.2
       local-pkg: 0.5.0
-      nuxt: 3.9.3(vite@5.0.12)
+      nuxt: 3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vite@5.0.12)
       vue-demi: 0.14.6(vue@3.4.15)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -8617,7 +8623,7 @@ packages:
       treemate: 0.3.11
       vdirs: 0.1.8(vue@3.4.15)
       vooks: 0.2.12(vue@3.4.15)
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
       vueuc: 0.4.58(vue@3.4.15)
     dev: true
 
@@ -8947,7 +8953,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt@3.9.3(vite@5.0.12):
+  /nuxt@3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vite@5.0.12):
     resolution: {integrity: sha512-IzBJAJImqCGfspVZzvznrALnFIJ5rPe+VJvY8OiccwRzWT8sEygVRjh3Mc64yWV6P59rz497wp9RBBBhuV2MVA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -8966,7 +8972,8 @@ packages:
       '@nuxt/schema': 3.9.3
       '@nuxt/telemetry': 2.5.3
       '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.9.3(vue@3.4.15)
+      '@nuxt/vite-builder': 3.9.3(@types/node@20.11.0)(typescript@5.3.3)(vue@3.4.15)
+      '@types/node': 20.11.0
       '@unhead/dom': 1.8.10
       '@unhead/ssr': 1.8.10
       '@unhead/vue': 1.8.10(vue@3.4.15)
@@ -9011,7 +9018,7 @@ packages:
       unplugin: 1.6.0
       unplugin-vue-router: 0.7.0(vue-router@4.2.5)(vue@3.4.15)
       untyped: 1.4.0
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
       vue-router: 4.2.5(vue@3.4.15)
@@ -9389,7 +9396,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pinia@2.1.7(vue@3.4.15):
+  /pinia@2.1.7(typescript@5.3.3)(vue@3.4.15):
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -9402,7 +9409,8 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.4.15
+      typescript: 5.3.3
+      vue: 3.4.15(typescript@5.3.3)
       vue-demi: 0.14.6(vue@3.4.15)
 
   /pirates@4.0.6:
@@ -9879,6 +9887,10 @@ packages:
       kleur: 3.0.3
       sisteransi: 1.0.5
     dev: true
+
+  /property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+    dev: false
 
   /proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -10952,6 +10964,10 @@ packages:
       next-tick: 1.1.0
     dev: true
 
+  /tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+    dev: false
+
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
     dev: true
@@ -10998,6 +11014,10 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  /toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+    dev: false
 
   /totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -11225,10 +11245,20 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  /type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: false
+
   /type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
     dev: true
+
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -11547,14 +11577,24 @@ packages:
       vue: ^3.0.11
     dependencies:
       evtd: 0.2.4
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
+
+  /vee-validate@4.12.5(vue@3.4.15):
+    resolution: {integrity: sha512-rvaDfLPSLwTk+mf016XWE4drB8yXzOsKXiKHTb9gNXNLTtQSZ0Ww26O0/xbIFQe+n3+u8Wv1Y8uO/aLDX4fxOg==}
+    peerDependencies:
+      vue: ^3.3.11
+    dependencies:
+      '@vue/devtools-api': 6.5.1
+      type-fest: 4.10.2
+      vue: 3.4.15(typescript@5.3.3)
+    dev: false
 
   /vfonts@0.0.3:
     resolution: {integrity: sha512-nguyw8L6Un8eelg1vQ31vIU2ESxqid7EYmy8V+MDeMaHBqaRSkg3dTBToC1PR00D89UzS/SLkfYPnx0Wf23IQQ==}
     dev: true
 
-  /vite-node@1.2.1:
+  /vite-node@1.2.1(@types/node@20.11.0):
     resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -11563,7 +11603,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12
+      vite: 5.0.12(@types/node@20.11.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11575,7 +11615,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker@0.6.2(vite@5.0.11):
+  /vite-plugin-checker@0.6.2(typescript@5.3.3)(vite@5.0.11):
     resolution: {integrity: sha512-YvvvQ+IjY09BX7Ab+1pjxkELQsBd4rPhWNw8WLBeFVxu/E7O+n6VYAqNsKdK/a2luFlX/sMpoWdGFfg4HvwdJQ==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -11619,7 +11659,8 @@ packages:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      vite: 5.0.11
+      typescript: 5.3.3
+      vite: 5.0.11(@types/node@20.11.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
@@ -11645,7 +11686,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.0.12
+      vite: 5.0.12(@types/node@20.11.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -11665,12 +11706,12 @@ packages:
       '@vue/compiler-dom': 3.4.15
       kolorist: 1.8.0
       magic-string: 0.30.5
-      vite: 5.0.12
+      vite: 5.0.12(@types/node@20.11.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@5.0.11:
+  /vite@5.0.11(@types/node@20.11.0):
     resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -11698,6 +11739,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.0
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.4
@@ -11705,7 +11747,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.0.12:
+  /vite@5.0.12(@types/node@20.11.0):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -11733,6 +11775,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.0
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.4
@@ -11762,7 +11805,7 @@ packages:
       - vue-router
     dev: true
 
-  /vitest@1.2.1(happy-dom@13.3.1):
+  /vitest@1.2.1(@types/node@20.11.0)(happy-dom@13.3.1):
     resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -11787,6 +11830,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@types/node': 20.11.0
       '@vitest/expect': 1.2.1
       '@vitest/runner': 1.2.1
       '@vitest/snapshot': 1.2.1
@@ -11806,8 +11850,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12
-      vite-node: 1.2.1
+      vite: 5.0.12(@types/node@20.11.0)
+      vite-node: 1.2.1(@types/node@20.11.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -11825,7 +11869,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       evtd: 0.2.4
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /vscode-jsonrpc@6.0.0:
@@ -11890,7 +11934,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
 
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -11902,10 +11946,10 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
-  /vue@3.4.15:
+  /vue@3.4.15(typescript@5.3.3):
     resolution: {integrity: sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==}
     peerDependencies:
       typescript: '*'
@@ -11918,6 +11962,7 @@ packages:
       '@vue/runtime-dom': 3.4.15
       '@vue/server-renderer': 3.4.15(vue@3.4.15)
       '@vue/shared': 3.4.15
+      typescript: 5.3.3
 
   /vueuc@0.4.58(vue@3.4.15):
     resolution: {integrity: sha512-Wnj/N8WbPRSxSt+9ji1jtDHPzda5h2OH/0sFBhvdxDRuyCZbjGg3/cKMaKqEoe+dErTexG2R+i6Q8S/Toq1MYg==}
@@ -11931,7 +11976,7 @@ packages:
       seemly: 0.3.8
       vdirs: 0.1.8(vue@3.4.15)
       vooks: 0.2.12(vue@3.4.15)
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /walker@1.0.8:
@@ -12203,6 +12248,15 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /yup@1.3.3:
+    resolution: {integrity: sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==}
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
+    dev: false
 
   /zhead@2.2.4:
     resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}


### PR DESCRIPTION
提交描述：重构登录和注册表单使用Tailwind和Vee-Validate，移除naive-ui

描述：
本次PR主要完成了以下工作：
- 移除了项目中登录和注册页面对naive-ui的依赖
- 重写了登录和注册表单的样式，使用Tailwind CSS替代
- 更新了表单验证逻辑，采用vee-validate验证替代naive-ui原先的内建验证