### PR TITLE
refactor: Login and SignUp remove-naive-ui-use-tailwind-vee-validate

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -33,6 +33,8 @@
     "@types/canvas-confetti": "^1.6.4",
     "axios": "^1.6.6",
     "canvas-confetti": "^1.9.2",
-    "pinia": "^2.1.7"
+    "pinia": "^2.1.7",
+    "vee-validate": "^4.12.5",
+    "yup": "^1.3.3"
   }
 }

--- a/apps/client/pages/Auth/FormInput.vue
+++ b/apps/client/pages/Auth/FormInput.vue
@@ -1,0 +1,39 @@
+<template>
+    <div>
+        <label :for="name" class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">{{ label }} <span
+                class="text-red-500">*</span></label>
+        <input :id="name" :name="name" :value="modelValue" @input="updateValue($event)" :type="type"
+            :placeholder="placeholder" class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm
+        placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none
+        focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50
+        dark:focus:bg-gray-600" :autocomplete="autocomplete" required>
+        <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">{{ errorMessage }}</p>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+    label: String,
+    name: String,
+    type: {
+        type: String,
+        default: 'text',
+    },
+    placeholder: String,
+    modelValue: [String, Number],
+    errorMessage: String,
+    autocomplete: {
+        type: String,
+        default: 'off',
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+function updateValue(event: Event) {
+    const target = event.target as HTMLInputElement;
+    emit('update:modelValue', target.value);
+}
+</script>

--- a/apps/client/pages/Auth/Login.vue
+++ b/apps/client/pages/Auth/Login.vue
@@ -1,109 +1,66 @@
 <template>
-  <div
-    className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8"
-  >
+  <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
     <div className="sm:mx-auto sm:w-full sm:max-w-sm">
       <img className="mx-auto h-10 w-auto" src="/logo.png" alt="earthworm" />
-      <h2
-        className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300"
-      >
+      <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-300">
         Log in to your account
       </h2>
     </div>
 
     <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <n-form ref="formEl" :rules="rules" :model="model">
-        <n-form-item path="phone" label="Phone" required>
-          <n-input v-model:value="model.phone" @keydown.enter.prevent @keyup.enter="handleLogin"/>
-        </n-form-item>
-        <n-form-item path="password" label="Password" required>
-          <n-input
-            v-model:value="model.password"
-            type="password"
-            @keydown.enter.prevent
-            @keyup.enter="handleLogin"
-          />
-        </n-form-item>
-        <n-button
-          type="primary"
-          size="large"
-          block
-          @click="handleLogin"
-          class="mt-2"
-        >
-          Log in
-        </n-button>
-      </n-form>
-
+      <form @submit.prevent="handleLogin" class="space-y-6" novalidate>
+        <FormInput label="Phone" name="phone" type="tel" placeholder="Please enter your phone number" v-model="phone"
+          :errorMessage="phoneError" />
+        <FormInput label="Password" name="password" type="password" placeholder="Please enter your password"
+          v-model="password" :errorMessage="passwordError" />
+        <div class="pt-2">
+          <button type="submit"
+            class="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Log in
+          </button>
+        </div>
+      </form>
       <p className="mt-10 text-center text-sm text-gray-500">
         Not an account?
-        <NuxtLink
-          href="/auth/signup"
-          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400"
-        >
+        <NuxtLink href="/auth/signup"
+          className="font-semibold text-[1.2em] leading-6 text-fuchsia-500 hover:text-fuchsia-400">
           Sign up
         </NuxtLink>
       </p>
     </div>
   </div>
 </template>
+
 <script setup lang="ts">
-import { type FormInst, type FormRules } from "naive-ui";
+import FormInput from "~/pages/Auth/FormInput.vue";
+import { useForm, useField } from 'vee-validate';
+import * as yup from 'yup';
 import { useAuth } from "~/composables/auth";
-import { ref } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { useMessage } from "naive-ui";
+import { useRouter, useRoute } from 'vue-router';
+import { type SignupFormValues } from "~/store/user"
 
-interface ModelType {
-  phone: string | null;
-  password: string | null;
-}
-
-const { login } = useAuth();
-
-const formEl = ref<FormInst | null>(null);
-const model = ref<ModelType>({
-  phone: null,
-  password: null,
+const schema = yup.object({
+  phone: yup.string().required("Please input your phone number").matches(/^1[3456789]\d{9}$/, "Please input correct phone number"),
+  password: yup.string().required("Please input your password").min(6, "Password length must be greater than 6"),
 });
 
-const rules: FormRules = {
-  phone: [
-    { required: true, message: "Please input your phone number" },
-    {
-      pattern: /^1[3456789]\d{9}$/,
-      message: "Please input correct phone number",
-    },
-  ],
-  password: [
-    { required: true, message: "Please input your password" },
-    { min: 6, message: "Password length must be greater than 6" },
-  ],
-};
+const { handleSubmit } = useForm<SignupFormValues>({
+  validationSchema: schema,
+});
 
-const message = useMessage();
+const { value: phone, errorMessage: phoneError } = useField<string>('phone');
+const { value: password, errorMessage: passwordError } = useField<string>('password');
+
 const router = useRouter();
 const route = useRoute();
+const { login } = useAuth();
 
-const handleLogin = () => {
-  function gotoPreviousPage() {
-    router.replace(route.query.callback?.toString() ?? "/");
+const handleLogin = handleSubmit(async (values) => {
+  try {
+    await login(values);
+    router.replace(route.query.callback?.toString() || '/');
+  } catch (error) {
+
   }
-
-  formEl.value?.validate(async (errors) => {
-    if (!errors) {
-      await login({
-        phone: model.value.phone ?? "",
-        password: model.value.password ?? "",
-      });
-
-      message.success("login success", {
-        duration: 500,
-        onLeave() {
-          gotoPreviousPage();
-        },
-      });
-    }
-  });
-};
+});
 </script>

--- a/apps/client/store/tests/user.spec.ts
+++ b/apps/client/store/tests/user.spec.ts
@@ -1,12 +1,20 @@
 import { setActivePinia, createPinia } from "pinia";
 import { it, expect, describe, vi, beforeEach } from "vitest";
-import { useUserStore, type User } from "../user";
+import { useUserStore, type User, type SignupFormValues } from "../user";
 
 function generateUserInfo() {
   return {
     userId: "123",
     username: "JohnDoe",
     phone: "1234567890",
+  };
+}
+
+function generateSignupInfo() {
+  return {
+    name: "JohnDoe",
+    phone: "12345678901",
+    password: "Password123",
   };
 }
 
@@ -48,4 +56,24 @@ describe("user", () => {
     expect(userStore.user).toBeFalsy();
     expect(userStore.getUserInfo()).toBeFalsy();
   });
+
+  it("should update user store on successful signup", async () => {
+    const signupInfo = generateSignupInfo();
+    const userStore = useUserStore();
+
+    await mockSignup(signupInfo);
+
+    expect(userStore.user).toBeDefined();
+    expect(userStore.user?.username).toBe(signupInfo.name);
+    expect(userStore.user?.phone).toBe(signupInfo.phone);
+  });
 });
+
+async function mockSignup(signupInfo: SignupFormValues) {
+  const userStore = useUserStore();
+  userStore.initUser({
+    userId: "newUserId",
+    username: signupInfo.name,
+    phone: signupInfo.phone,
+  });
+}

--- a/apps/client/store/user.ts
+++ b/apps/client/store/user.ts
@@ -6,6 +6,12 @@ export interface User {
   phone: string;
 }
 
+export interface SignupFormValues {
+  phone: string;
+  name: string;
+  password: string;
+}
+
 const LOCAL_STORAGE_KEY = "userInfo";
 
 export const useUserStore = defineStore("user", () => {


### PR DESCRIPTION
本次修改：重构登录和注册表单移除原先naive-ui，使用Tailwind和Vee-Validate

描述：
本次PR主要完成了以下工作：

移除了登录注册页面中对naive-ui的依赖
重写了登录和注册表单的样式，使用Tailwind CSS替代原先的样式
更新了表单验证逻辑，采用vee-validate替代naive-ui表单验证