### PR TITLE
Fix/fix courses 18

### DIFF
--- a/scripts/course/courses/18.json
+++ b/scripts/course/courses/18.json
@@ -615,11 +615,6 @@
 		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
 	{
-		"chinese": "的所有的细节",
-		"english": "of the plan",
-		"soundmark": "/ðə/ /plæn/"
-	},
-	{
 		"chinese": "一起",
 		"english": "together",
 		"soundmark": "/tə'ɡɛðɚ/"

--- a/scripts/course/courses/18.json
+++ b/scripts/course/courses/18.json
@@ -610,9 +610,9 @@
 		"soundmark": "/ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
 	{
-		"chinese": "我们(现在)正在讨论这个计划",
-		"english": "we are discussing all the details",
-		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/"
+		"chinese": "我们(现在)正在讨论这个计划的所有的细节",
+		"english": "we are discussing all the details of the plan",
+		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
 	{
 		"chinese": "的所有的细节",


### PR DESCRIPTION
问题描述：原先字段英文中文应为一整个段落             
"chinese": "我们(现在)正在讨论这个计划",
"english": "we are discussing all the details",
"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ "

修复后：
"chinese": "我们(现在)正在讨论这个计划的所有的细节",
"english": "we are discussing all the details of the plan",
"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
