### PR TITLE
fix: Prevents adding Spaces after the last word

### DIFF
--- a/apps/client/components/main/Question.vue
+++ b/apps/client/components/main/Question.vue
@@ -8,22 +8,12 @@
             i - 1 === activeInputIndex && focusing
               ? 'text-fuchsia-500 border-b-fuchsia-500'
               : 'text-[#20202099] border-b-gray-300 dark:text-gray-300 dark:border-b-gray-400',
-          ]"
-        >
+          ]">
           {{ userInputWords[i - 1] }}
         </div>
       </template>
-      <input
-        ref="inputEl"
-        class="absolute h-full w-full opacity-0"
-        type="text"
-        v-model="inputValue"
-        @keyup="handleKeyup"
-        @keydown="handleKeydown"
-        @focus="handleInputFocus"
-        @blur="handleBlur"
-        autoFocus
-      />
+      <input ref="inputEl" class="absolute h-full w-full opacity-0" type="text" v-model="inputValue" @keyup="handleKeyup"
+        @keydown="handleKeydown" @focus="handleInputFocus" @blur="handleBlur" autoFocus />
     </div>
     <div class="mt-12 text-xl dark:text-gray-50">
       {{
@@ -89,6 +79,12 @@ function registerShortcutKeyForInputEl() {
       // remove the last space and the last letter
       e.preventDefault();
       inputValue.value = inputValue.value.slice(0, -2);
+    }
+    // 新增逻辑：阻止在最后一个单词后添加空格
+    const words = inputValue.value.trim().split(" ");
+    const isLastWord = words.length === courseStore.wordCount;
+    if (e.code === "Space" && isLastWord) {
+      e.preventDefault();
     }
   }
 


### PR DESCRIPTION
问题描述：
用户在最后一个输入框输入内容时，单词输入完按下空格没被阻止，导致会有多余的字符

修改：
新增最后一个单词后的空格阻止逻辑： 当用户完成最后一个单词的输入并尝试在其后添加空格时，进行阻止