### PR TITLE
fix: fix course 18 the ninety-first field is incorrect

### DIFF
--- a/scripts/course/courses/15.5.json
+++ b/scripts/course/courses/15.5.json
@@ -1,907 +1,907 @@
 [
-  {
-    "chinese": "吃",
-    "english": "to eat",
-    "soundmark": "/tə/ /it/"
-  },
-  {
-    "chinese": "鸡蛋",
-    "english": "eggs",
-    "soundmark": "/ɛgz/"
-  },
-  {
-    "chinese": "吃鸡蛋",
-    "english": "to eat eggs",
-    "soundmark": "/tə/ /it/ /ɛgz/"
-  },
-  {
-    "chinese": "正在吃",
-    "english": "eating",
-    "soundmark": "/'itɪŋ/"
-  },
-  {
-    "chinese": "正在吃鸡蛋",
-    "english": "eating eggs",
-    "soundmark": "/'itɪŋ/ /ɛgz/"
-  },
-  {
-    "chinese": "我是",
-    "english": "I am",
-    "soundmark": "/aɪ/ /æm/"
-  },
-  {
-    "chinese": "我是星荣",
-    "english": "I am Xingrong",
-    "soundmark": "/aɪ/ /æm/"
-  },
-  {
-    "chinese": "正在吃鸡蛋",
-    "english": "eating eggs",
-    "soundmark": "/'itɪŋ/ /ɛgz/"
-  },
-  {
-    "chinese": "我正在吃鸡蛋",
-    "english": "I am eating eggs",
-    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
-  },
-  {
-    "chinese": "厨房",
-    "english": "the kitchen",
-    "soundmark": "/ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "在厨房里",
-    "english": "in the kitchen",
-    "soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "我在厨房里（现在）正在吃鸡蛋",
-    "english": "I am eating eggs in the kitchen",
-    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "我在厨房里（过去）正在吃鸡蛋",
-    "english": "I was eating eggs in the kitchen",
-    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
-  },
-  {
-    "chinese": "你在厨房里（现在）正在吃鸡蛋",
-    "english": "you are eating eggs in the kitchen",
-    "soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
-  },
-  {
-    "chinese": "你在厨房里（过去）正在吃鸡蛋",
-    "english": "you were eating eggs in the kitchen",
-    "soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "他们",
-    "english": "they",
-    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-  },
-  {
-    "chinese": "他们在厨房里（现在）正在吃鸡蛋",
-    "english": "they are eating eggs in the kitchen",
-    "soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
-  },
-  {
-    "chinese": "他们在厨房里（过去）正在吃鸡蛋",
-    "english": "they were eating eggs in the kitchen",
-    "soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "喝",
-    "english": "to drink",
-    "soundmark": "/tə/ /drɪŋk/"
-  },
-  {
-    "chinese": "茶",
-    "english": "tea",
-    "soundmark": "/ti/"
-  },
-  {
-    "chinese": "喝茶",
-    "english": "to drink tea",
-    "soundmark": "/tə/ /drɪŋk/ /ti/"
-  },
-  {
-    "chinese": "正在喝",
-    "english": "drinking",
-    "soundmark": "/'drɪŋkɪŋ/"
-  },
-  {
-    "chinese": "正在喝茶",
-    "english": "drinking tea",
-    "soundmark": "/'drɪŋkɪŋ/ /ti/"
-  },
-  {
-    "chinese": "他们",
-    "english": "they",
-    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-  },
-  {
-    "chinese": "他们（现在）正在喝茶",
-    "english": "they are drinking tea",
-    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
-  },
-  {
-    "chinese": "花园",
-    "english": "the garden",
-    "soundmark": "/ðə/ /ˈɡɑrdn/"
-  },
-  {
-    "chinese": "在花园里",
-    "english": "in the garden",
-    "soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
-  },
-  {
-    "chinese": "他们在花园里（现在）正在喝",
-    "english": "they are drinking tea in the garden",
-    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-  },
-  {
-    "chinese": "茶",
-    "english": "tea",
-    "soundmark": "/tiː/"
-  },
-  {
-    "chinese": "他们在花园里（过去）正在喝茶",
-    "english": "they were drinking tea in the garden",
-    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-  },
-  {
-    "chinese": "我在厨房里（过去）正在吃鸡蛋",
-    "english": "I was eating eggs in the kitchen",
-    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "与此同时",
-    "english": "while",
-    "soundmark": "/waɪl/"
-  },
-  {
-    "chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
-    "english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
-    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-  },
-  {
-    "chinese": "教",
-    "english": "to teach",
-    "soundmark": "/tə/ /titʃ/"
-  },
-  {
-    "chinese": "我们",
-    "english": "us",
-    "soundmark": "/ʌs/"
-  },
-  {
-    "chinese": "教我们",
-    "english": "to teach us",
-    "soundmark": "/tə/ /titʃ/ /ʌs/"
-  },
-  {
-    "chinese": "正在教",
-    "english": "teaching",
-    "soundmark": "/'titʃɪŋ/"
-  },
-  {
-    "chinese": "正在教我们",
-    "english": "teaching us",
-    "soundmark": "/'titʃɪŋ/ /ʌs/"
-  },
-  {
-    "chinese": "说",
-    "english": "to speak",
-    "soundmark": "/tə/ /spik/"
-  },
-  {
-    "chinese": "英语",
-    "english": "English",
-    "soundmark": "/ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "说英语",
-    "english": "to speak English",
-    "soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "如何",
-    "english": "how",
-    "soundmark": "/haʊ/"
-  },
-  {
-    "chinese": "如何说英语",
-    "english": "how to speak English",
-    "soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "正在教我们如何说英语",
-    "english": "teaching us how to speak English",
-    "soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
-  },
-  {
-    "chinese": "星荣正在教我们如何说英语",
-    "english": "Xingrong is teaching us how to speak English",
-    "soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "星荣（过去）正在教我们如何说英语",
-    "english": "Xingrong was teaching us how to speak English",
-    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "学习",
-    "english": "to learn",
-    "soundmark": "/tə/ /lɝn/"
-  },
-  {
-    "chinese": "英语",
-    "english": "English",
-    "soundmark": "/ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "学习英语",
-    "english": "to learn English",
-    "soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "正在学习",
-    "english": "learning",
-    "soundmark": "/'lɝnɪŋ/"
-  },
-  {
-    "chinese": "正在学习英语",
-    "english": "learning English",
-    "soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
-  },
-  {
-    "chinese": "我正在学习英语",
-    "english": "I am learning English",
-    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "视频",
-    "english": "videos",
-    "soundmark": "/'vɪdɪoz/"
-  },
-  {
-    "chinese": "他的",
-    "english": "his",
-    "soundmark": "/hɪz/"
-  },
-  {
-    "chinese": "他的视频",
-    "english": "his videos",
-    "soundmark": "/hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "观看",
-    "english": "to watch",
-    "soundmark": "/tə/ /wɑtʃ/"
-  },
-  {
-    "chinese": "观看他的视频",
-    "english": "to watch his videos",
-    "soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "正在观看",
-    "english": "watching",
-    "soundmark": "/'wɑtʃɪŋ/"
-  },
-  {
-    "chinese": "正在观看他的视频",
-    "english": "watching his videos",
-    "soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "通过......的方式",
-    "english": "by",
-    "soundmark": "/baɪ/"
-  },
-  {
-    "chinese": "通过观看他的视频的方式",
-    "english": "by watching his videos",
-    "soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "我正在学习英语",
-    "english": "I am learning English",
-    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "我正在通过观看他的视频的方式学习英语",
-    "english": "I am learning English by watching his videos",
-    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "我（过去）正在通过观看他的视频的方式学习英语",
-    "english": "I was learning English by watching his videos",
-    "soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "星荣（过去）正在教我们如何说英语",
-    "english": "Xingrong was teaching us how to speak English",
-    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-  },
-  {
-    "chinese": "与此同时",
-    "english": "while",
-    "soundmark": "/waɪl/"
-  },
-  {
-    "chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
-    "english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
-    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-  },
-  {
-    "chinese": "走路",
-    "english": "to walk",
-    "soundmark": "/tə/ /wɔk/"
-  },
-  {
-    "chinese": "家",
-    "english": "home",
-    "soundmark": "/hom/"
-  },
-  {
-    "chinese": "走路回家",
-    "english": "to walk home",
-    "soundmark": "/tə/ /wɔk/ /hom/"
-  },
-  {
-    "chinese": "学校",
-    "english": "school",
-    "soundmark": "/skul/"
-  },
-  {
-    "chinese": "从",
-    "english": "from",
-    "soundmark": "/frʌm/"
-  },
-  {
-    "chinese": "从学校",
-    "english": "from school",
-    "soundmark": "/frʌm/ /skul/"
-  },
-  {
-    "chinese": "从学校走路回家",
-    "english": "to walk home from school",
-    "soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
-  },
-  {
-    "chinese": "正在从学校走路回家",
-    "english": "walking home from school",
-    "soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
-  },
-  {
-    "chinese": "我正在从学校走路回家",
-    "english": "I am walking home from school",
-    "soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "我（过去）正在从学校走路回家",
-    "english": "I was walking home from school",
-    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-  },
-  {
-    "chinese": "朋友",
-    "english": "friend",
-    "soundmark": "/frɛnd/"
-  },
-  {
-    "chinese": "老的",
-    "english": "old",
-    "soundmark": "/old/"
-  },
-  {
-    "chinese": "一个老朋友",
-    "english": "an old friend",
-    "soundmark": "/ən/ /old/ /frɛnd/"
-  },
-  {
-    "chinese": "遇见",
-    "english": "to meet",
-    "soundmark": "/tə/ /mit/"
-  },
-  {
-    "chinese": "遇见一个老朋友",
-    "english": "to meet an old friend",
-    "soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
-  },
-  {
-    "chinese": "我（过去）遇见一个老朋友",
-    "english": "I met an old friend",
-    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
-  },
-  {
-    "chinese": "我（过去）正在从学校走路回家",
-    "english": "I was walking home from school",
-    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-  },
-  {
-    "chinese": "当......的时候",
-    "english": "when",
-    "soundmark": "/wɛn/"
-  },
-  {
-    "chinese": "当我（过去）正在从学校走路回家的时候",
-    "english": "when I was walking home from school",
-    "soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-  },
-  {
-    "chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
-    "english": "I met an old friend when I was walking home from school",
-    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-  },
-  {
-    "chinese": "睡觉",
-    "english": "to sleep",
-    "soundmark": "/tə/ /slip/"
-  },
-  {
-    "chinese": "卧室",
-    "english": "the bedroom",
-    "soundmark": "/ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "在卧室里",
-    "english": "in the bedroom",
-    "soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "在卧室里睡觉",
-    "english": "to sleep in the bedroom",
-    "soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "正在睡觉",
-    "english": "sleeping",
-    "soundmark": "/ˈslipɪŋ/"
-  },
-  {
-    "chinese": "正在在卧室里睡觉",
-    "english": "sleeping in the bedroom",
-    "soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
-  },
-  {
-    "chinese": "我正在在卧室里睡觉",
-    "english": "I am sleeping in the bedroom",
-    "soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "我（过去）正在在卧室里睡觉",
-    "english": "I was sleeping in the bedroom",
-    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "打电话",
-    "english": "to call",
-    "soundmark": "/tə/ /kɔl/"
-  },
-  {
-    "chinese": "打电话给我",
-    "english": "to call me",
-    "soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
-  },
-  {
-    "chinese": "她",
-    "english": "she",
-    "soundmark": "/ʃi/"
-  },
-  {
-    "chinese": "她（过去）打电话给我",
-    "english": "she called me",
-    "soundmark": "/ʃi/ /kɔld/ /mi/"
-  },
-  {
-    "chinese": "当......的时候",
-    "english": "when",
-    "soundmark": "/wɛn/"
-  },
-  {
-    "chinese": "当她（过去）打电话给我的时候",
-    "english": "when she called me",
-    "soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
-  },
-  {
-    "chinese": "我（过去）正在在卧室里睡觉",
-    "english": "I was sleeping in the bedroom",
-    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
-    "english": "I was sleeping in the bedroom when she called me",
-    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
-  },
-  {
-    "chinese": "玩",
-    "english": "to play",
-    "soundmark": "/tə/ /ple/"
-  },
-  {
-    "chinese": "钢琴",
-    "english": "the piano",
-    "soundmark": "/ðə/ /pɪ'æno/"
-  },
-  {
-    "chinese": "弹钢琴",
-    "english": "to play the piano",
-    "soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
-  },
-  {
-    "chinese": "正在玩",
-    "english": "playing",
-    "soundmark": "/pleɪŋ/"
-  },
-  {
-    "chinese": "正在弹钢琴",
-    "english": "playing the piano",
-    "soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
-  },
-  {
-    "chinese": "她正在弹钢琴",
-    "english": "she is playing the piano",
-    "soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
-  },
-  {
-    "chinese": "她（过去）正在弹钢琴",
-    "english": "she was playing the piano",
-    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
-  },
-  {
-    "chinese": "起居室；客厅",
-    "english": "the living room",
-    "soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
-  },
-  {
-    "chinese": "在客厅",
-    "english": "in the living room",
-    "soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-  },
-  {
-    "chinese": "她（过去）正在在客厅弹钢琴",
-    "english": "she was playing the piano in the living room",
-    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-  },
-  {
-    "chinese": "与此同时",
-    "english": "while",
-    "soundmark": "/waɪl/"
-  },
-  {
-    "chinese": "我（过去）正在在卧室里睡觉",
-    "english": "I was sleeping in the bedroom",
-    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
-    "english": "she was playing the piano in the living room while I was sleeping in the bedroom",
-    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-  },
-  {
-    "chinese": "中文 原形 第三人称单数 过去式想要",
-    "english": "want wants",
-    "soundmark": "/wanted/"
-  },
-  {
-    "chinese": "喜欢",
-    "english": "like likes",
-    "soundmark": "/liked/"
-  },
-  {
-    "chinese": "有；(+to)不得不",
-    "english": "have has",
-    "soundmark": "/had/"
-  },
-  {
-    "chinese": "计划",
-    "english": "plan plans",
-    "soundmark": "/planned/"
-  },
-  {
-    "chinese": "需要",
-    "english": "need needs",
-    "soundmark": "/needed/"
-  },
-  {
-    "chinese": "做",
-    "english": "do does",
-    "soundmark": "/did/"
-  },
-  {
-    "chinese": "告诉",
-    "english": "tell tells",
-    "soundmark": "/told/"
-  },
-  {
-    "chinese": "说话",
-    "english": "talk talks",
-    "soundmark": "/talked/"
-  },
-  {
-    "chinese": "是 be（am）",
-    "english": "is",
-    "soundmark": "/was/"
-  },
-  {
-    "chinese": "是 be（is ）",
-    "english": "is",
-    "soundmark": "/was/"
-  },
-  {
-    "chinese": "是 be（are）",
-    "english": "is",
-    "soundmark": "/were/"
-  },
-  {
-    "chinese": "看到",
-    "english": "see sees",
-    "soundmark": "/saw/"
-  },
-  {
-    "chinese": "吃",
-    "english": "eat eats",
-    "soundmark": "/ate/"
-  },
-  {
-    "chinese": "喝",
-    "english": "drink drinks",
-    "soundmark": "/drank/"
-  },
-  {
-    "chinese": "知道",
-    "english": "know knows",
-    "soundmark": "/knew/"
-  },
-  {
-    "chinese": "忘记",
-    "english": "forget forgets",
-    "soundmark": "/forgot/"
-  },
-  {
-    "chinese": "失去",
-    "english": "lose loses",
-    "soundmark": "/lost/"
-  },
-  {
-    "chinese": "离开",
-    "english": "leave leaves",
-    "soundmark": "/left/"
-  },
-  {
-    "chinese": "睡觉",
-    "english": "sleep sleeps",
-    "soundmark": "/slept/"
-  },
-  {
-    "chinese": "明白",
-    "english": "understand understands",
-    "soundmark": "/understood/"
-  },
-  {
-    "chinese": "买",
-    "english": "buy buys",
-    "soundmark": "/bought/"
-  },
-  {
-    "chinese": "洗",
-    "english": "wash washes",
-    "soundmark": "/washed/"
-  },
-  {
-    "chinese": "打电话",
-    "english": "call calls",
-    "soundmark": "/called/"
-  },
-  {
-    "chinese": "帮助",
-    "english": "help helps",
-    "soundmark": "/helped/"
-  },
-  {
-    "chinese": "相信",
-    "english": "believe believes",
-    "soundmark": "/believed/"
-  },
-  {
-    "chinese": "学习",
-    "english": "study studies",
-    "soundmark": "/studied/"
-  },
-  {
-    "chinese": "解释",
-    "english": "explain explains",
-    "soundmark": "/explained/"
-  },
-  {
-    "chinese": "问",
-    "english": "ask asks",
-    "soundmark": "/asked/"
-  },
-  {
-    "chinese": "飞",
-    "english": "fly flies",
-    "soundmark": "/flew/"
-  },
-  {
-    "chinese": "阅读",
-    "english": "read reads",
-    "soundmark": "/read/"
-  },
-  {
-    "chinese": "走路",
-    "english": "walk walks",
-    "soundmark": "/walked/"
-  },
-  {
-    "chinese": "跳舞",
-    "english": "dance dances",
-    "soundmark": "/danced/"
-  },
-  {
-    "chinese": "回答",
-    "english": "answer answers",
-    "soundmark": "/answered/"
-  },
-  {
-    "chinese": "工作",
-    "english": "work works",
-    "soundmark": "/worked/"
-  },
-  {
-    "chinese": "待在",
-    "english": "stay stays",
-    "soundmark": "/stayed/"
-  },
-  {
-    "chinese": "支付",
-    "english": "pay pays",
-    "soundmark": "/paid/"
-  },
-  {
-    "chinese": "旅行",
-    "english": "travel travels",
-    "soundmark": "/traveled/"
-  },
-  {
-    "chinese": "给",
-    "english": "give gives",
-    "soundmark": "/gave/"
-  },
-  {
-    "chinese": "达到",
-    "english": "get gets",
-    "soundmark": "/got/"
-  },
-  {
-    "chinese": "锁",
-    "english": "lock locks",
-    "soundmark": "/locked/"
-  },
-  {
-    "chinese": "记得",
-    "english": "remember remembers",
-    "soundmark": "/remembered/"
-  },
-  {
-    "chinese": "清理",
-    "english": "clean cleans",
-    "soundmark": "/cleaned/"
-  },
-  {
-    "chinese": "找到",
-    "english": "find finds",
-    "soundmark": "/found/"
-  },
-  {
-    "chinese": "关闭",
-    "english": "close closes",
-    "soundmark": "/closed/"
-  },
-  {
-    "chinese": "教",
-    "english": "teach teaches",
-    "soundmark": "/taught/"
-  },
-  {
-    "chinese": "展示",
-    "english": "show shows",
-    "soundmark": "/showed/"
-  },
-  {
-    "chinese": "让",
-    "english": "let lets",
-    "soundmark": "/let/"
-  },
-  {
-    "chinese": "休息",
-    "english": "rest rests",
-    "soundmark": "/rested/"
-  },
-  {
-    "chinese": "用",
-    "english": "use uses",
-    "soundmark": "/used/"
-  },
-  {
-    "chinese": "做饭",
-    "english": "cook cooks",
-    "soundmark": "/cooked/"
-  },
-  {
-    "chinese": "去",
-    "english": "go goes",
-    "soundmark": "/went/"
-  },
-  {
-    "chinese": "决定",
-    "english": "decide decides",
-    "soundmark": "/decided/"
-  },
-  {
-    "chinese": "驾驶",
-    "english": "drive drives",
-    "soundmark": "/drove/"
-  },
-  {
-    "chinese": "改变",
-    "english": "change changes",
-    "soundmark": "/changed/"
-  },
-  {
-    "chinese": "尝试",
-    "english": "try tries",
-    "soundmark": "/tried/"
-  },
-  {
-    "chinese": "停止",
-    "english": "stop stops",
-    "soundmark": "/Stopped/"
-  },
-  {
-    "chinese": "参加",
-    "english": "join joins",
-    "soundmark": "/joined/"
-  },
-  {
-    "chinese": "邀请",
-    "english": "invite invites",
-    "soundmark": "/invited/"
-  },
-  {
-    "chinese": "拒绝",
-    "english": "refuse refuses",
-    "soundmark": "/refused/"
-  },
-  {
-    "chinese": "接受",
-    "english": "accept accepts",
-    "soundmark": "/accepted/"
-  },
-  {
-    "chinese": "学习",
-    "english": "learn learns",
-    "soundmark": "/learnt/"
-  },
-  {
-    "chinese": "完成",
-    "english": "finish finishes",
-    "soundmark": "/finished/"
-  },
-  {
-    "chinese": "看",
-    "english": "watch watches",
-    "soundmark": "/watched/"
-  },
-  {
-    "chinese": "游泳",
-    "english": "swim swims",
-    "soundmark": "/swam/"
-  },
-  {
-    "chinese": "掌握",
-    "english": "master masters",
-    "soundmark": "/mastered/"
-  }
+	{
+		"chinese": "吃",
+		"english": "to eat",
+		"soundmark": "/tə/ /it/"
+	},
+	{
+		"chinese": "鸡蛋",
+		"english": "eggs",
+		"soundmark": "/ɛgz/"
+	},
+	{
+		"chinese": "吃鸡蛋",
+		"english": "to eat eggs",
+		"soundmark": "/tə/ /it/ /ɛgz/"
+	},
+	{
+		"chinese": "正在吃",
+		"english": "eating",
+		"soundmark": "/'itɪŋ/"
+	},
+	{
+		"chinese": "正在吃鸡蛋",
+		"english": "eating eggs",
+		"soundmark": "/'itɪŋ/ /ɛgz/"
+	},
+	{
+		"chinese": "我是",
+		"english": "I am",
+		"soundmark": "/aɪ/ /æm/"
+	},
+	{
+		"chinese": "我是星荣",
+		"english": "I am Xingrong",
+		"soundmark": "/aɪ/ /æm/"
+	},
+	{
+		"chinese": "正在吃鸡蛋",
+		"english": "eating eggs",
+		"soundmark": "/'itɪŋ/ /ɛgz/"
+	},
+	{
+		"chinese": "我正在吃鸡蛋",
+		"english": "I am eating eggs",
+		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
+	},
+	{
+		"chinese": "厨房",
+		"english": "the kitchen",
+		"soundmark": "/ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "在厨房里",
+		"english": "in the kitchen",
+		"soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "我在厨房里（现在）正在吃鸡蛋",
+		"english": "I am eating eggs in the kitchen",
+		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "我在厨房里（过去）正在吃鸡蛋",
+		"english": "I was eating eggs in the kitchen",
+		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
+	},
+	{
+		"chinese": "你在厨房里（现在）正在吃鸡蛋",
+		"english": "you are eating eggs in the kitchen",
+		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
+	},
+	{
+		"chinese": "你在厨房里（过去）正在吃鸡蛋",
+		"english": "you were eating eggs in the kitchen",
+		"soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "他们",
+		"english": "they",
+		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+	},
+	{
+		"chinese": "他们在厨房里（现在）正在吃鸡蛋",
+		"english": "they are eating eggs in the kitchen",
+		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
+	},
+	{
+		"chinese": "他们在厨房里（过去）正在吃鸡蛋",
+		"english": "they were eating eggs in the kitchen",
+		"soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "喝",
+		"english": "to drink",
+		"soundmark": "/tə/ /drɪŋk/"
+	},
+	{
+		"chinese": "茶",
+		"english": "tea",
+		"soundmark": "/ti/"
+	},
+	{
+		"chinese": "喝茶",
+		"english": "to drink tea",
+		"soundmark": "/tə/ /drɪŋk/ /ti/"
+	},
+	{
+		"chinese": "正在喝",
+		"english": "drinking",
+		"soundmark": "/'drɪŋkɪŋ/"
+	},
+	{
+		"chinese": "正在喝茶",
+		"english": "drinking tea",
+		"soundmark": "/'drɪŋkɪŋ/ /ti/"
+	},
+	{
+		"chinese": "他们",
+		"english": "they",
+		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+	},
+	{
+		"chinese": "他们（现在）正在喝茶",
+		"english": "they are drinking tea",
+		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
+	},
+	{
+		"chinese": "花园",
+		"english": "the garden",
+		"soundmark": "/ðə/ /ˈɡɑrdn/"
+	},
+	{
+		"chinese": "在花园里",
+		"english": "in the garden",
+		"soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
+	},
+	{
+		"chinese": "他们在花园里（现在）正在喝",
+		"english": "they are drinking tea in the garden",
+		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+	},
+	{
+		"chinese": "茶",
+		"english": "tea",
+		"soundmark": "/tiː/"
+	},
+	{
+		"chinese": "他们在花园里（过去）正在喝茶",
+		"english": "they were drinking tea in the garden",
+		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+	},
+	{
+		"chinese": "我在厨房里（过去）正在吃鸡蛋",
+		"english": "I was eating eggs in the kitchen",
+		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "与此同时",
+		"english": "while",
+		"soundmark": "/waɪl/"
+	},
+	{
+		"chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
+		"english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
+		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+	},
+	{
+		"chinese": "教",
+		"english": "to teach",
+		"soundmark": "/tə/ /titʃ/"
+	},
+	{
+		"chinese": "我们",
+		"english": "us",
+		"soundmark": "/ʌs/"
+	},
+	{
+		"chinese": "教我们",
+		"english": "to teach us",
+		"soundmark": "/tə/ /titʃ/ /ʌs/"
+	},
+	{
+		"chinese": "正在教",
+		"english": "teaching",
+		"soundmark": "/'titʃɪŋ/"
+	},
+	{
+		"chinese": "正在教我们",
+		"english": "teaching us",
+		"soundmark": "/'titʃɪŋ/ /ʌs/"
+	},
+	{
+		"chinese": "说",
+		"english": "to speak",
+		"soundmark": "/tə/ /spik/"
+	},
+	{
+		"chinese": "英语",
+		"english": "English",
+		"soundmark": "/ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "说英语",
+		"english": "to speak English",
+		"soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "如何",
+		"english": "how",
+		"soundmark": "/haʊ/"
+	},
+	{
+		"chinese": "如何说英语",
+		"english": "how to speak English",
+		"soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "正在教我们如何说英语",
+		"english": "teaching us how to speak English",
+		"soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
+	},
+	{
+		"chinese": "星荣正在教我们如何说英语",
+		"english": "Xingrong is teaching us how to speak English",
+		"soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "星荣（过去）正在教我们如何说英语",
+		"english": "Xingrong was teaching us how to speak English",
+		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "学习",
+		"english": "to learn",
+		"soundmark": "/tə/ /lɝn/"
+	},
+	{
+		"chinese": "英语",
+		"english": "English",
+		"soundmark": "/ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "学习英语",
+		"english": "to learn English",
+		"soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "正在学习",
+		"english": "learning",
+		"soundmark": "/'lɝnɪŋ/"
+	},
+	{
+		"chinese": "正在学习英语",
+		"english": "learning English",
+		"soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
+	},
+	{
+		"chinese": "我正在学习英语",
+		"english": "I am learning English",
+		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "视频",
+		"english": "videos",
+		"soundmark": "/'vɪdɪoz/"
+	},
+	{
+		"chinese": "他的",
+		"english": "his",
+		"soundmark": "/hɪz/"
+	},
+	{
+		"chinese": "他的视频",
+		"english": "his videos",
+		"soundmark": "/hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "观看",
+		"english": "to watch",
+		"soundmark": "/tə/ /wɑtʃ/"
+	},
+	{
+		"chinese": "观看他的视频",
+		"english": "to watch his videos",
+		"soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "正在观看",
+		"english": "watching",
+		"soundmark": "/'wɑtʃɪŋ/"
+	},
+	{
+		"chinese": "正在观看他的视频",
+		"english": "watching his videos",
+		"soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "通过......的方式",
+		"english": "by",
+		"soundmark": "/baɪ/"
+	},
+	{
+		"chinese": "通过观看他的视频的方式",
+		"english": "by watching his videos",
+		"soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "我正在学习英语",
+		"english": "I am learning English",
+		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "我正在通过观看他的视频的方式学习英语",
+		"english": "I am learning English by watching his videos",
+		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "我（过去）正在通过观看他的视频的方式学习英语",
+		"english": "I was learning English by watching his videos",
+		"soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "星荣（过去）正在教我们如何说英语",
+		"english": "Xingrong was teaching us how to speak English",
+		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+	},
+	{
+		"chinese": "与此同时",
+		"english": "while",
+		"soundmark": "/waɪl/"
+	},
+	{
+		"chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
+		"english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
+		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+	},
+	{
+		"chinese": "走路",
+		"english": "to walk",
+		"soundmark": "/tə/ /wɔk/"
+	},
+	{
+		"chinese": "家",
+		"english": "home",
+		"soundmark": "/hom/"
+	},
+	{
+		"chinese": "走路回家",
+		"english": "to walk home",
+		"soundmark": "/tə/ /wɔk/ /hom/"
+	},
+	{
+		"chinese": "学校",
+		"english": "school",
+		"soundmark": "/skul/"
+	},
+	{
+		"chinese": "从",
+		"english": "from",
+		"soundmark": "/frʌm/"
+	},
+	{
+		"chinese": "从学校",
+		"english": "from school",
+		"soundmark": "/frʌm/ /skul/"
+	},
+	{
+		"chinese": "从学校走路回家",
+		"english": "to walk home from school",
+		"soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
+	},
+	{
+		"chinese": "正在从学校走路回家",
+		"english": "walking home from school",
+		"soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
+	},
+	{
+		"chinese": "我正在从学校走路回家",
+		"english": "I am walking home from school",
+		"soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "我（过去）正在从学校走路回家",
+		"english": "I was walking home from school",
+		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+	},
+	{
+		"chinese": "朋友",
+		"english": "friend",
+		"soundmark": "/frɛnd/"
+	},
+	{
+		"chinese": "老的",
+		"english": "old",
+		"soundmark": "/old/"
+	},
+	{
+		"chinese": "一个老朋友",
+		"english": "an old friend",
+		"soundmark": "/ən/ /old/ /frɛnd/"
+	},
+	{
+		"chinese": "遇见",
+		"english": "to meet",
+		"soundmark": "/tə/ /mit/"
+	},
+	{
+		"chinese": "遇见一个老朋友",
+		"english": "to meet an old friend",
+		"soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
+	},
+	{
+		"chinese": "我（过去）遇见一个老朋友",
+		"english": "I met an old friend",
+		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
+	},
+	{
+		"chinese": "我（过去）正在从学校走路回家",
+		"english": "I was walking home from school",
+		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+	},
+	{
+		"chinese": "当......的时候",
+		"english": "when",
+		"soundmark": "/wɛn/"
+	},
+	{
+		"chinese": "当我（过去）正在从学校走路回家的时候",
+		"english": "when I was walking home from school",
+		"soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+	},
+	{
+		"chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
+		"english": "I met an old friend when I was walking home from school",
+		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+	},
+	{
+		"chinese": "睡觉",
+		"english": "to sleep",
+		"soundmark": "/tə/ /slip/"
+	},
+	{
+		"chinese": "卧室",
+		"english": "the bedroom",
+		"soundmark": "/ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "在卧室里",
+		"english": "in the bedroom",
+		"soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "在卧室里睡觉",
+		"english": "to sleep in the bedroom",
+		"soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "正在睡觉",
+		"english": "sleeping",
+		"soundmark": "/ˈslipɪŋ/"
+	},
+	{
+		"chinese": "正在在卧室里睡觉",
+		"english": "sleeping in the bedroom",
+		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
+	},
+	{
+		"chinese": "我正在在卧室里睡觉",
+		"english": "I am sleeping in the bedroom",
+		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "我（过去）正在在卧室里睡觉",
+		"english": "I was sleeping in the bedroom",
+		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "打电话",
+		"english": "to call",
+		"soundmark": "/tə/ /kɔl/"
+	},
+	{
+		"chinese": "打电话给我",
+		"english": "to call me",
+		"soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
+	},
+	{
+		"chinese": "她",
+		"english": "she",
+		"soundmark": "/ʃi/"
+	},
+	{
+		"chinese": "她（过去）打电话给我",
+		"english": "she called me",
+		"soundmark": "/ʃi/ /kɔld/ /mi/"
+	},
+	{
+		"chinese": "当......的时候",
+		"english": "when",
+		"soundmark": "/wɛn/"
+	},
+	{
+		"chinese": "当她（过去）打电话给我的时候",
+		"english": "when she called me",
+		"soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
+	},
+	{
+		"chinese": "我（过去）正在在卧室里睡觉",
+		"english": "I was sleeping in the bedroom",
+		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
+		"english": "I was sleeping in the bedroom when she called me",
+		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
+	},
+	{
+		"chinese": "玩",
+		"english": "to play",
+		"soundmark": "/tə/ /ple/"
+	},
+	{
+		"chinese": "钢琴",
+		"english": "the piano",
+		"soundmark": "/ðə/ /pɪ'æno/"
+	},
+	{
+		"chinese": "弹钢琴",
+		"english": "to play the piano",
+		"soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
+	},
+	{
+		"chinese": "正在玩",
+		"english": "playing",
+		"soundmark": "/pleɪŋ/"
+	},
+	{
+		"chinese": "正在弹钢琴",
+		"english": "playing the piano",
+		"soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
+	},
+	{
+		"chinese": "她正在弹钢琴",
+		"english": "she is playing the piano",
+		"soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
+	},
+	{
+		"chinese": "她（过去）正在弹钢琴",
+		"english": "she was playing the piano",
+		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
+	},
+	{
+		"chinese": "起居室；客厅",
+		"english": "the living room",
+		"soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
+	},
+	{
+		"chinese": "在客厅",
+		"english": "in the living room",
+		"soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+	},
+	{
+		"chinese": "她（过去）正在在客厅弹钢琴",
+		"english": "she was playing the piano in the living room",
+		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+	},
+	{
+		"chinese": "与此同时",
+		"english": "while",
+		"soundmark": "/waɪl/"
+	},
+	{
+		"chinese": "我（过去）正在在卧室里睡觉",
+		"english": "I was sleeping in the bedroom",
+		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
+		"english": "she was playing the piano in the living room while I was sleeping in the bedroom",
+		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+	},
+	{
+		"chinese": "中文 原形 第三人称单数 过去式想要",
+		"english": "want wants",
+		"soundmark": "/wanted/"
+	},
+	{
+		"chinese": "喜欢",
+		"english": "like likes",
+		"soundmark": "/liked/"
+	},
+	{
+		"chinese": "有；(+to)不得不",
+		"english": "have has",
+		"soundmark": "/had/"
+	},
+	{
+		"chinese": "计划",
+		"english": "plan plans",
+		"soundmark": "/planned/"
+	},
+	{
+		"chinese": "需要",
+		"english": "need needs",
+		"soundmark": "/needed/"
+	},
+	{
+		"chinese": "做",
+		"english": "do does",
+		"soundmark": "/did/"
+	},
+	{
+		"chinese": "告诉",
+		"english": "tell tells",
+		"soundmark": "/told/"
+	},
+	{
+		"chinese": "说话",
+		"english": "talk talks",
+		"soundmark": "/talked/"
+	},
+	{
+		"chinese": "是 be（am）",
+		"english": "is",
+		"soundmark": "/was/"
+	},
+	{
+		"chinese": "是 be（is ）",
+		"english": "is",
+		"soundmark": "/was/"
+	},
+	{
+		"chinese": "是 be（are）",
+		"english": "is",
+		"soundmark": "/were/"
+	},
+	{
+		"chinese": "看到",
+		"english": "see sees",
+		"soundmark": "/saw/"
+	},
+	{
+		"chinese": "吃",
+		"english": "eat eats",
+		"soundmark": "/ate/"
+	},
+	{
+		"chinese": "喝",
+		"english": "drink drinks",
+		"soundmark": "/drank/"
+	},
+	{
+		"chinese": "知道",
+		"english": "know knows",
+		"soundmark": "/knew/"
+	},
+	{
+		"chinese": "忘记",
+		"english": "forget forgets",
+		"soundmark": "/forgot/"
+	},
+	{
+		"chinese": "失去",
+		"english": "lose loses",
+		"soundmark": "/lost/"
+	},
+	{
+		"chinese": "离开",
+		"english": "leave leaves",
+		"soundmark": "/left/"
+	},
+	{
+		"chinese": "睡觉",
+		"english": "sleep sleeps",
+		"soundmark": "/slept/"
+	},
+	{
+		"chinese": "明白",
+		"english": "understand understands",
+		"soundmark": "/understood/"
+	},
+	{
+		"chinese": "买",
+		"english": "buy buys",
+		"soundmark": "/bought/"
+	},
+	{
+		"chinese": "洗",
+		"english": "wash washes",
+		"soundmark": "/washed/"
+	},
+	{
+		"chinese": "打电话",
+		"english": "call calls",
+		"soundmark": "/called/"
+	},
+	{
+		"chinese": "帮助",
+		"english": "help helps",
+		"soundmark": "/helped/"
+	},
+	{
+		"chinese": "相信",
+		"english": "believe believes",
+		"soundmark": "/believed/"
+	},
+	{
+		"chinese": "学习",
+		"english": "study studies",
+		"soundmark": "/studied/"
+	},
+	{
+		"chinese": "解释",
+		"english": "explain explains",
+		"soundmark": "/explained/"
+	},
+	{
+		"chinese": "问",
+		"english": "ask asks",
+		"soundmark": "/asked/"
+	},
+	{
+		"chinese": "飞",
+		"english": "fly flies",
+		"soundmark": "/flew/"
+	},
+	{
+		"chinese": "阅读",
+		"english": "read reads",
+		"soundmark": "/read/"
+	},
+	{
+		"chinese": "走路",
+		"english": "walk walks",
+		"soundmark": "/walked/"
+	},
+	{
+		"chinese": "跳舞",
+		"english": "dance dances",
+		"soundmark": "/danced/"
+	},
+	{
+		"chinese": "回答",
+		"english": "answer answers",
+		"soundmark": "/answered/"
+	},
+	{
+		"chinese": "工作",
+		"english": "work works",
+		"soundmark": "/worked/"
+	},
+	{
+		"chinese": "待在",
+		"english": "stay stays",
+		"soundmark": "/stayed/"
+	},
+	{
+		"chinese": "支付",
+		"english": "pay pays",
+		"soundmark": "/paid/"
+	},
+	{
+		"chinese": "旅行",
+		"english": "travel travels",
+		"soundmark": "/traveled/"
+	},
+	{
+		"chinese": "给",
+		"english": "give gives",
+		"soundmark": "/gave/"
+	},
+	{
+		"chinese": "达到",
+		"english": "get gets",
+		"soundmark": "/got/"
+	},
+	{
+		"chinese": "锁",
+		"english": "lock locks",
+		"soundmark": "/locked/"
+	},
+	{
+		"chinese": "记得",
+		"english": "remember remembers",
+		"soundmark": "/remembered/"
+	},
+	{
+		"chinese": "清理",
+		"english": "clean cleans",
+		"soundmark": "/cleaned/"
+	},
+	{
+		"chinese": "找到",
+		"english": "find finds",
+		"soundmark": "/found/"
+	},
+	{
+		"chinese": "关闭",
+		"english": "close closes",
+		"soundmark": "/closed/"
+	},
+	{
+		"chinese": "教",
+		"english": "teach teaches",
+		"soundmark": "/taught/"
+	},
+	{
+		"chinese": "展示",
+		"english": "show shows",
+		"soundmark": "/showed/"
+	},
+	{
+		"chinese": "让",
+		"english": "let lets",
+		"soundmark": "/let/"
+	},
+	{
+		"chinese": "休息",
+		"english": "rest rests",
+		"soundmark": "/rested/"
+	},
+	{
+		"chinese": "用",
+		"english": "use uses",
+		"soundmark": "/used/"
+	},
+	{
+		"chinese": "做饭",
+		"english": "cook cooks",
+		"soundmark": "/cooked/"
+	},
+	{
+		"chinese": "去",
+		"english": "go goes",
+		"soundmark": "/went/"
+	},
+	{
+		"chinese": "决定",
+		"english": "decide decides",
+		"soundmark": "/decided/"
+	},
+	{
+		"chinese": "驾驶",
+		"english": "drive drives",
+		"soundmark": "/drove/"
+	},
+	{
+		"chinese": "改变",
+		"english": "change changes",
+		"soundmark": "/changed/"
+	},
+	{
+		"chinese": "尝试",
+		"english": "try tries",
+		"soundmark": "/tried/"
+	},
+	{
+		"chinese": "停止",
+		"english": "stop stops",
+		"soundmark": "/Stopped/"
+	},
+	{
+		"chinese": "参加",
+		"english": "join joins",
+		"soundmark": "/joined/"
+	},
+	{
+		"chinese": "邀请",
+		"english": "invite invites",
+		"soundmark": "/invited/"
+	},
+	{
+		"chinese": "拒绝",
+		"english": "refuse refuses",
+		"soundmark": "/refused/"
+	},
+	{
+		"chinese": "接受",
+		"english": "accept accepts",
+		"soundmark": "/accepted/"
+	},
+	{
+		"chinese": "学习",
+		"english": "learn learns",
+		"soundmark": "/learnt/"
+	},
+	{
+		"chinese": "完成",
+		"english": "finish finishes",
+		"soundmark": "/finished/"
+	},
+	{
+		"chinese": "看",
+		"english": "watch watches",
+		"soundmark": "/watched/"
+	},
+	{
+		"chinese": "游泳",
+		"english": "swim swims",
+		"soundmark": "/swam/"
+	},
+	{
+		"chinese": "掌握",
+		"english": "master masters",
+		"soundmark": "/mastered/"
+	}
 ]

--- a/scripts/course/courses/15.5.json
+++ b/scripts/course/courses/15.5.json
@@ -1,907 +1,907 @@
 [
-	{
-		"chinese": "吃",
-		"english": "to eat",
-		"soundmark": "/tə/ /it/"
-	},
-	{
-		"chinese": "鸡蛋",
-		"english": "eggs",
-		"soundmark": "/ɛgz/"
-	},
-	{
-		"chinese": "吃鸡蛋",
-		"english": "to eat eggs",
-		"soundmark": "/tə/ /it/ /ɛgz/"
-	},
-	{
-		"chinese": "正在吃",
-		"english": "eating",
-		"soundmark": "/'itɪŋ/"
-	},
-	{
-		"chinese": "正在吃鸡蛋",
-		"english": "eating eggs",
-		"soundmark": "/'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "我是",
-		"english": "I am",
-		"soundmark": "/aɪ/ /æm/"
-	},
-	{
-		"chinese": "我是星荣",
-		"english": "I am Xingrong",
-		"soundmark": "/aɪ/ /æm/"
-	},
-	{
-		"chinese": "正在吃鸡蛋",
-		"english": "eating eggs",
-		"soundmark": "/'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "我正在吃鸡蛋",
-		"english": "I am eating eggs",
-		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "厨房",
-		"english": "the kitchen",
-		"soundmark": "/ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "在厨房里",
-		"english": "in the kitchen",
-		"soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "我在厨房里（现在）正在吃鸡蛋",
-		"english": "I am eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
-		"english": "I was eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "你在厨房里（现在）正在吃鸡蛋",
-		"english": "you are eating eggs in the kitchen",
-		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
-	},
-	{
-		"chinese": "你在厨房里（过去）正在吃鸡蛋",
-		"english": "you were eating eggs in the kitchen",
-		"soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "他们在厨房里（现在）正在吃鸡蛋",
-		"english": "they are eating eggs in the kitchen",
-		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
-	},
-	{
-		"chinese": "他们在厨房里（过去）正在吃鸡蛋",
-		"english": "they were eating eggs in the kitchen",
-		"soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "喝",
-		"english": "to drink",
-		"soundmark": "/tə/ /drɪŋk/"
-	},
-	{
-		"chinese": "茶",
-		"english": "tea",
-		"soundmark": "/ti/"
-	},
-	{
-		"chinese": "喝茶",
-		"english": "to drink tea",
-		"soundmark": "/tə/ /drɪŋk/ /ti/"
-	},
-	{
-		"chinese": "正在喝",
-		"english": "drinking",
-		"soundmark": "/'drɪŋkɪŋ/"
-	},
-	{
-		"chinese": "正在喝茶",
-		"english": "drinking tea",
-		"soundmark": "/'drɪŋkɪŋ/ /ti/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "他们（现在）正在喝茶",
-		"english": "they are drinking tea",
-		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
-	},
-	{
-		"chinese": "花园",
-		"english": "the garden",
-		"soundmark": "/ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "在花园里",
-		"english": "in the garden",
-		"soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "他们在花园里（现在）正在喝",
-		"english": "they are drinking tea in the garden",
-		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "茶",
-		"english": "tea",
-		"soundmark": "/tiː/"
-	},
-	{
-		"chinese": "他们在花园里（过去）正在喝茶",
-		"english": "they were drinking tea in the garden",
-		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
-		"english": "I was eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
-		"english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
-		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "教",
-		"english": "to teach",
-		"soundmark": "/tə/ /titʃ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "us",
-		"soundmark": "/ʌs/"
-	},
-	{
-		"chinese": "教我们",
-		"english": "to teach us",
-		"soundmark": "/tə/ /titʃ/ /ʌs/"
-	},
-	{
-		"chinese": "正在教",
-		"english": "teaching",
-		"soundmark": "/'titʃɪŋ/"
-	},
-	{
-		"chinese": "正在教我们",
-		"english": "teaching us",
-		"soundmark": "/'titʃɪŋ/ /ʌs/"
-	},
-	{
-		"chinese": "说",
-		"english": "to speak",
-		"soundmark": "/tə/ /spik/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "说英语",
-		"english": "to speak English",
-		"soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "如何说英语",
-		"english": "how to speak English",
-		"soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "正在教我们如何说英语",
-		"english": "teaching us how to speak English",
-		"soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "星荣正在教我们如何说英语",
-		"english": "Xingrong is teaching us how to speak English",
-		"soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语",
-		"english": "Xingrong was teaching us how to speak English",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "学习",
-		"english": "to learn",
-		"soundmark": "/tə/ /lɝn/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "学习英语",
-		"english": "to learn English",
-		"soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "正在学习",
-		"english": "learning",
-		"soundmark": "/'lɝnɪŋ/"
-	},
-	{
-		"chinese": "正在学习英语",
-		"english": "learning English",
-		"soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在学习英语",
-		"english": "I am learning English",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "视频",
-		"english": "videos",
-		"soundmark": "/'vɪdɪoz/"
-	},
-	{
-		"chinese": "他的",
-		"english": "his",
-		"soundmark": "/hɪz/"
-	},
-	{
-		"chinese": "他的视频",
-		"english": "his videos",
-		"soundmark": "/hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "观看",
-		"english": "to watch",
-		"soundmark": "/tə/ /wɑtʃ/"
-	},
-	{
-		"chinese": "观看他的视频",
-		"english": "to watch his videos",
-		"soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "正在观看",
-		"english": "watching",
-		"soundmark": "/'wɑtʃɪŋ/"
-	},
-	{
-		"chinese": "正在观看他的视频",
-		"english": "watching his videos",
-		"soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "通过......的方式",
-		"english": "by",
-		"soundmark": "/baɪ/"
-	},
-	{
-		"chinese": "通过观看他的视频的方式",
-		"english": "by watching his videos",
-		"soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "我正在学习英语",
-		"english": "I am learning English",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "我正在通过观看他的视频的方式学习英语",
-		"english": "I am learning English by watching his videos",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在通过观看他的视频的方式学习英语",
-		"english": "I was learning English by watching his videos",
-		"soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语",
-		"english": "Xingrong was teaching us how to speak English",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
-		"english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "走路",
-		"english": "to walk",
-		"soundmark": "/tə/ /wɔk/"
-	},
-	{
-		"chinese": "家",
-		"english": "home",
-		"soundmark": "/hom/"
-	},
-	{
-		"chinese": "走路回家",
-		"english": "to walk home",
-		"soundmark": "/tə/ /wɔk/ /hom/"
-	},
-	{
-		"chinese": "学校",
-		"english": "school",
-		"soundmark": "/skul/"
-	},
-	{
-		"chinese": "从",
-		"english": "from",
-		"soundmark": "/frʌm/"
-	},
-	{
-		"chinese": "从学校",
-		"english": "from school",
-		"soundmark": "/frʌm/ /skul/"
-	},
-	{
-		"chinese": "从学校走路回家",
-		"english": "to walk home from school",
-		"soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "正在从学校走路回家",
-		"english": "walking home from school",
-		"soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在从学校走路回家",
-		"english": "I am walking home from school",
-		"soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在从学校走路回家",
-		"english": "I was walking home from school",
-		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "朋友",
-		"english": "friend",
-		"soundmark": "/frɛnd/"
-	},
-	{
-		"chinese": "老的",
-		"english": "old",
-		"soundmark": "/old/"
-	},
-	{
-		"chinese": "一个老朋友",
-		"english": "an old friend",
-		"soundmark": "/ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "遇见",
-		"english": "to meet",
-		"soundmark": "/tə/ /mit/"
-	},
-	{
-		"chinese": "遇见一个老朋友",
-		"english": "to meet an old friend",
-		"soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "我（过去）遇见一个老朋友",
-		"english": "I met an old friend",
-		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "我（过去）正在从学校走路回家",
-		"english": "I was walking home from school",
-		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我（过去）正在从学校走路回家的时候",
-		"english": "when I was walking home from school",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
-		"english": "I met an old friend when I was walking home from school",
-		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "to sleep",
-		"soundmark": "/tə/ /slip/"
-	},
-	{
-		"chinese": "卧室",
-		"english": "the bedroom",
-		"soundmark": "/ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "在卧室里",
-		"english": "in the bedroom",
-		"soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "在卧室里睡觉",
-		"english": "to sleep in the bed room",
-		"soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "正在睡觉",
-		"english": "sleeping",
-		"soundmark": "/ˈslipɪŋ/"
-	},
-	{
-		"chinese": "正在在卧室里睡觉",
-		"english": "sleeping in the bedroom",
-		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在在卧室里睡觉",
-		"english": "I am sleeping in the bedroom",
-		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "to call",
-		"soundmark": "/tə/ /kɔl/"
-	},
-	{
-		"chinese": "打电话给我",
-		"english": "to call me",
-		"soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/"
-	},
-	{
-		"chinese": "她（过去）打电话给我",
-		"english": "she called me",
-		"soundmark": "/ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当她（过去）打电话给我的时候",
-		"english": "when she called me",
-		"soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom when she called me",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "玩",
-		"english": "to play",
-		"soundmark": "/tə/ /ple/"
-	},
-	{
-		"chinese": "钢琴",
-		"english": "the piano",
-		"soundmark": "/ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "弹钢琴",
-		"english": "to play the piano",
-		"soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "正在玩",
-		"english": "playing",
-		"soundmark": "/pleɪŋ/"
-	},
-	{
-		"chinese": "正在弹钢琴",
-		"english": "playing the piano",
-		"soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她正在弹钢琴",
-		"english": "she is playing the piano",
-		"soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "她（过去）正在弹钢琴",
-		"english": "she was playing the piano",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "起居室；客厅",
-		"english": "the living room",
-		"soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "在客厅",
-		"english": "in the living room",
-		"soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "她（过去）正在在客厅弹钢琴",
-		"english": "she was playing the piano in the living room",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
-		"english": "she was playing the piano in the living room while I was sleeping in the bedroom",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "中文 原形 第三人称单数 过去式想要",
-		"english": "want wants",
-		"soundmark": "/wanted/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like likes",
-		"soundmark": "/liked/"
-	},
-	{
-		"chinese": "有；(+to)不得不",
-		"english": "have has",
-		"soundmark": "/had/"
-	},
-	{
-		"chinese": "计划",
-		"english": "plan plans",
-		"soundmark": "/planned/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need needs",
-		"soundmark": "/needed/"
-	},
-	{
-		"chinese": "做",
-		"english": "do does",
-		"soundmark": "/did/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "tell tells",
-		"soundmark": "/told/"
-	},
-	{
-		"chinese": "说话",
-		"english": "talk talks",
-		"soundmark": "/talked/"
-	},
-	{
-		"chinese": "是 be（am）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（is ）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（are）",
-		"english": "is",
-		"soundmark": "/were/"
-	},
-	{
-		"chinese": "看到",
-		"english": "see sees",
-		"soundmark": "/saw/"
-	},
-	{
-		"chinese": "吃",
-		"english": "eat eats",
-		"soundmark": "/ate/"
-	},
-	{
-		"chinese": "喝",
-		"english": "drink drinks",
-		"soundmark": "/drank/"
-	},
-	{
-		"chinese": "知道",
-		"english": "know knows",
-		"soundmark": "/knew/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "forget forgets",
-		"soundmark": "/forgot/"
-	},
-	{
-		"chinese": "失去",
-		"english": "lose loses",
-		"soundmark": "/lost/"
-	},
-	{
-		"chinese": "离开",
-		"english": "leave leaves",
-		"soundmark": "/left/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "sleep sleeps",
-		"soundmark": "/slept/"
-	},
-	{
-		"chinese": "明白",
-		"english": "understand understands",
-		"soundmark": "/understood/"
-	},
-	{
-		"chinese": "买",
-		"english": "buy buys",
-		"soundmark": "/bought/"
-	},
-	{
-		"chinese": "洗",
-		"english": "wash washes",
-		"soundmark": "/washed/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "call calls",
-		"soundmark": "/called/"
-	},
-	{
-		"chinese": "帮助",
-		"english": "help helps",
-		"soundmark": "/helped/"
-	},
-	{
-		"chinese": "相信",
-		"english": "believe believes",
-		"soundmark": "/believed/"
-	},
-	{
-		"chinese": "学习",
-		"english": "study studies",
-		"soundmark": "/studied/"
-	},
-	{
-		"chinese": "解释",
-		"english": "explain explains",
-		"soundmark": "/explained/"
-	},
-	{
-		"chinese": "问",
-		"english": "ask asks",
-		"soundmark": "/asked/"
-	},
-	{
-		"chinese": "飞",
-		"english": "fly flies",
-		"soundmark": "/flew/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "read reads",
-		"soundmark": "/read/"
-	},
-	{
-		"chinese": "走路",
-		"english": "walk walks",
-		"soundmark": "/walked/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "dance dances",
-		"soundmark": "/danced/"
-	},
-	{
-		"chinese": "回答",
-		"english": "answer answers",
-		"soundmark": "/answered/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work works",
-		"soundmark": "/worked/"
-	},
-	{
-		"chinese": "待在",
-		"english": "stay stays",
-		"soundmark": "/stayed/"
-	},
-	{
-		"chinese": "支付",
-		"english": "pay pays",
-		"soundmark": "/paid/"
-	},
-	{
-		"chinese": "旅行",
-		"english": "travel travels",
-		"soundmark": "/traveled/"
-	},
-	{
-		"chinese": "给",
-		"english": "give gives",
-		"soundmark": "/gave/"
-	},
-	{
-		"chinese": "达到",
-		"english": "get gets",
-		"soundmark": "/got/"
-	},
-	{
-		"chinese": "锁",
-		"english": "lock locks",
-		"soundmark": "/locked/"
-	},
-	{
-		"chinese": "记得",
-		"english": "remember remembers",
-		"soundmark": "/remembered/"
-	},
-	{
-		"chinese": "清理",
-		"english": "clean cleans",
-		"soundmark": "/cleaned/"
-	},
-	{
-		"chinese": "找到",
-		"english": "find finds",
-		"soundmark": "/found/"
-	},
-	{
-		"chinese": "关闭",
-		"english": "close closes",
-		"soundmark": "/closed/"
-	},
-	{
-		"chinese": "教",
-		"english": "teach teaches",
-		"soundmark": "/taught/"
-	},
-	{
-		"chinese": "展示",
-		"english": "show shows",
-		"soundmark": "/showed/"
-	},
-	{
-		"chinese": "让",
-		"english": "let lets",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "休息",
-		"english": "rest rests",
-		"soundmark": "/rested/"
-	},
-	{
-		"chinese": "用",
-		"english": "use uses",
-		"soundmark": "/used/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "cook cooks",
-		"soundmark": "/cooked/"
-	},
-	{
-		"chinese": "去",
-		"english": "go goes",
-		"soundmark": "/went/"
-	},
-	{
-		"chinese": "决定",
-		"english": "decide decides",
-		"soundmark": "/decided/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "drive drives",
-		"soundmark": "/drove/"
-	},
-	{
-		"chinese": "改变",
-		"english": "change changes",
-		"soundmark": "/changed/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "try tries",
-		"soundmark": "/tried/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop stops",
-		"soundmark": "/Stopped/"
-	},
-	{
-		"chinese": "参加",
-		"english": "join joins",
-		"soundmark": "/joined/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "invite invites",
-		"soundmark": "/invited/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "refuse refuses",
-		"soundmark": "/refused/"
-	},
-	{
-		"chinese": "接受",
-		"english": "accept accepts",
-		"soundmark": "/accepted/"
-	},
-	{
-		"chinese": "学习",
-		"english": "learn learns",
-		"soundmark": "/learnt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "finish finishes",
-		"soundmark": "/finished/"
-	},
-	{
-		"chinese": "看",
-		"english": "watch watches",
-		"soundmark": "/watched/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "swim swims",
-		"soundmark": "/swam/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "master masters",
-		"soundmark": "/mastered/"
-	}
+  {
+    "chinese": "吃",
+    "english": "to eat",
+    "soundmark": "/tə/ /it/"
+  },
+  {
+    "chinese": "鸡蛋",
+    "english": "eggs",
+    "soundmark": "/ɛgz/"
+  },
+  {
+    "chinese": "吃鸡蛋",
+    "english": "to eat eggs",
+    "soundmark": "/tə/ /it/ /ɛgz/"
+  },
+  {
+    "chinese": "正在吃",
+    "english": "eating",
+    "soundmark": "/'itɪŋ/"
+  },
+  {
+    "chinese": "正在吃鸡蛋",
+    "english": "eating eggs",
+    "soundmark": "/'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "我是",
+    "english": "I am",
+    "soundmark": "/aɪ/ /æm/"
+  },
+  {
+    "chinese": "我是星荣",
+    "english": "I am Xingrong",
+    "soundmark": "/aɪ/ /æm/"
+  },
+  {
+    "chinese": "正在吃鸡蛋",
+    "english": "eating eggs",
+    "soundmark": "/'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "我正在吃鸡蛋",
+    "english": "I am eating eggs",
+    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "厨房",
+    "english": "the kitchen",
+    "soundmark": "/ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "在厨房里",
+    "english": "in the kitchen",
+    "soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "我在厨房里（现在）正在吃鸡蛋",
+    "english": "I am eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我在厨房里（过去）正在吃鸡蛋",
+    "english": "I was eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "你在厨房里（现在）正在吃鸡蛋",
+    "english": "you are eating eggs in the kitchen",
+    "soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
+  },
+  {
+    "chinese": "你在厨房里（过去）正在吃鸡蛋",
+    "english": "you were eating eggs in the kitchen",
+    "soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "他们在厨房里（现在）正在吃鸡蛋",
+    "english": "they are eating eggs in the kitchen",
+    "soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
+  },
+  {
+    "chinese": "他们在厨房里（过去）正在吃鸡蛋",
+    "english": "they were eating eggs in the kitchen",
+    "soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "喝",
+    "english": "to drink",
+    "soundmark": "/tə/ /drɪŋk/"
+  },
+  {
+    "chinese": "茶",
+    "english": "tea",
+    "soundmark": "/ti/"
+  },
+  {
+    "chinese": "喝茶",
+    "english": "to drink tea",
+    "soundmark": "/tə/ /drɪŋk/ /ti/"
+  },
+  {
+    "chinese": "正在喝",
+    "english": "drinking",
+    "soundmark": "/'drɪŋkɪŋ/"
+  },
+  {
+    "chinese": "正在喝茶",
+    "english": "drinking tea",
+    "soundmark": "/'drɪŋkɪŋ/ /ti/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "他们（现在）正在喝茶",
+    "english": "they are drinking tea",
+    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
+  },
+  {
+    "chinese": "花园",
+    "english": "the garden",
+    "soundmark": "/ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "在花园里",
+    "english": "in the garden",
+    "soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "他们在花园里（现在）正在喝",
+    "english": "they are drinking tea in the garden",
+    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "茶",
+    "english": "tea",
+    "soundmark": "/tiː/"
+  },
+  {
+    "chinese": "他们在花园里（过去）正在喝茶",
+    "english": "they were drinking tea in the garden",
+    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "我在厨房里（过去）正在吃鸡蛋",
+    "english": "I was eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
+    "english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
+    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "教",
+    "english": "to teach",
+    "soundmark": "/tə/ /titʃ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "us",
+    "soundmark": "/ʌs/"
+  },
+  {
+    "chinese": "教我们",
+    "english": "to teach us",
+    "soundmark": "/tə/ /titʃ/ /ʌs/"
+  },
+  {
+    "chinese": "正在教",
+    "english": "teaching",
+    "soundmark": "/'titʃɪŋ/"
+  },
+  {
+    "chinese": "正在教我们",
+    "english": "teaching us",
+    "soundmark": "/'titʃɪŋ/ /ʌs/"
+  },
+  {
+    "chinese": "说",
+    "english": "to speak",
+    "soundmark": "/tə/ /spik/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "说英语",
+    "english": "to speak English",
+    "soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "如何说英语",
+    "english": "how to speak English",
+    "soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "正在教我们如何说英语",
+    "english": "teaching us how to speak English",
+    "soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "星荣正在教我们如何说英语",
+    "english": "Xingrong is teaching us how to speak English",
+    "soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语",
+    "english": "Xingrong was teaching us how to speak English",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "学习",
+    "english": "to learn",
+    "soundmark": "/tə/ /lɝn/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "学习英语",
+    "english": "to learn English",
+    "soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "正在学习",
+    "english": "learning",
+    "soundmark": "/'lɝnɪŋ/"
+  },
+  {
+    "chinese": "正在学习英语",
+    "english": "learning English",
+    "soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在学习英语",
+    "english": "I am learning English",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "视频",
+    "english": "videos",
+    "soundmark": "/'vɪdɪoz/"
+  },
+  {
+    "chinese": "他的",
+    "english": "his",
+    "soundmark": "/hɪz/"
+  },
+  {
+    "chinese": "他的视频",
+    "english": "his videos",
+    "soundmark": "/hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "观看",
+    "english": "to watch",
+    "soundmark": "/tə/ /wɑtʃ/"
+  },
+  {
+    "chinese": "观看他的视频",
+    "english": "to watch his videos",
+    "soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "正在观看",
+    "english": "watching",
+    "soundmark": "/'wɑtʃɪŋ/"
+  },
+  {
+    "chinese": "正在观看他的视频",
+    "english": "watching his videos",
+    "soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "通过......的方式",
+    "english": "by",
+    "soundmark": "/baɪ/"
+  },
+  {
+    "chinese": "通过观看他的视频的方式",
+    "english": "by watching his videos",
+    "soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "我正在学习英语",
+    "english": "I am learning English",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "我正在通过观看他的视频的方式学习英语",
+    "english": "I am learning English by watching his videos",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在通过观看他的视频的方式学习英语",
+    "english": "I was learning English by watching his videos",
+    "soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语",
+    "english": "Xingrong was teaching us how to speak English",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
+    "english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "走路",
+    "english": "to walk",
+    "soundmark": "/tə/ /wɔk/"
+  },
+  {
+    "chinese": "家",
+    "english": "home",
+    "soundmark": "/hom/"
+  },
+  {
+    "chinese": "走路回家",
+    "english": "to walk home",
+    "soundmark": "/tə/ /wɔk/ /hom/"
+  },
+  {
+    "chinese": "学校",
+    "english": "school",
+    "soundmark": "/skul/"
+  },
+  {
+    "chinese": "从",
+    "english": "from",
+    "soundmark": "/frʌm/"
+  },
+  {
+    "chinese": "从学校",
+    "english": "from school",
+    "soundmark": "/frʌm/ /skul/"
+  },
+  {
+    "chinese": "从学校走路回家",
+    "english": "to walk home from school",
+    "soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "正在从学校走路回家",
+    "english": "walking home from school",
+    "soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在从学校走路回家",
+    "english": "I am walking home from school",
+    "soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在从学校走路回家",
+    "english": "I was walking home from school",
+    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "朋友",
+    "english": "friend",
+    "soundmark": "/frɛnd/"
+  },
+  {
+    "chinese": "老的",
+    "english": "old",
+    "soundmark": "/old/"
+  },
+  {
+    "chinese": "一个老朋友",
+    "english": "an old friend",
+    "soundmark": "/ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "遇见",
+    "english": "to meet",
+    "soundmark": "/tə/ /mit/"
+  },
+  {
+    "chinese": "遇见一个老朋友",
+    "english": "to meet an old friend",
+    "soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "我（过去）遇见一个老朋友",
+    "english": "I met an old friend",
+    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "我（过去）正在从学校走路回家",
+    "english": "I was walking home from school",
+    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我（过去）正在从学校走路回家的时候",
+    "english": "when I was walking home from school",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
+    "english": "I met an old friend when I was walking home from school",
+    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "to sleep",
+    "soundmark": "/tə/ /slip/"
+  },
+  {
+    "chinese": "卧室",
+    "english": "the bedroom",
+    "soundmark": "/ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "在卧室里",
+    "english": "in the bedroom",
+    "soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "在卧室里睡觉",
+    "english": "to sleep in the bedroom",
+    "soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "正在睡觉",
+    "english": "sleeping",
+    "soundmark": "/ˈslipɪŋ/"
+  },
+  {
+    "chinese": "正在在卧室里睡觉",
+    "english": "sleeping in the bedroom",
+    "soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在在卧室里睡觉",
+    "english": "I am sleeping in the bedroom",
+    "soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "to call",
+    "soundmark": "/tə/ /kɔl/"
+  },
+  {
+    "chinese": "打电话给我",
+    "english": "to call me",
+    "soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/"
+  },
+  {
+    "chinese": "她（过去）打电话给我",
+    "english": "she called me",
+    "soundmark": "/ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当她（过去）打电话给我的时候",
+    "english": "when she called me",
+    "soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom when she called me",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "玩",
+    "english": "to play",
+    "soundmark": "/tə/ /ple/"
+  },
+  {
+    "chinese": "钢琴",
+    "english": "the piano",
+    "soundmark": "/ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "弹钢琴",
+    "english": "to play the piano",
+    "soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "正在玩",
+    "english": "playing",
+    "soundmark": "/pleɪŋ/"
+  },
+  {
+    "chinese": "正在弹钢琴",
+    "english": "playing the piano",
+    "soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她正在弹钢琴",
+    "english": "she is playing the piano",
+    "soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "她（过去）正在弹钢琴",
+    "english": "she was playing the piano",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "起居室；客厅",
+    "english": "the living room",
+    "soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "在客厅",
+    "english": "in the living room",
+    "soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "她（过去）正在在客厅弹钢琴",
+    "english": "she was playing the piano in the living room",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
+    "english": "she was playing the piano in the living room while I was sleeping in the bedroom",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "中文 原形 第三人称单数 过去式想要",
+    "english": "want wants",
+    "soundmark": "/wanted/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like likes",
+    "soundmark": "/liked/"
+  },
+  {
+    "chinese": "有；(+to)不得不",
+    "english": "have has",
+    "soundmark": "/had/"
+  },
+  {
+    "chinese": "计划",
+    "english": "plan plans",
+    "soundmark": "/planned/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need needs",
+    "soundmark": "/needed/"
+  },
+  {
+    "chinese": "做",
+    "english": "do does",
+    "soundmark": "/did/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "tell tells",
+    "soundmark": "/told/"
+  },
+  {
+    "chinese": "说话",
+    "english": "talk talks",
+    "soundmark": "/talked/"
+  },
+  {
+    "chinese": "是 be（am）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（is ）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（are）",
+    "english": "is",
+    "soundmark": "/were/"
+  },
+  {
+    "chinese": "看到",
+    "english": "see sees",
+    "soundmark": "/saw/"
+  },
+  {
+    "chinese": "吃",
+    "english": "eat eats",
+    "soundmark": "/ate/"
+  },
+  {
+    "chinese": "喝",
+    "english": "drink drinks",
+    "soundmark": "/drank/"
+  },
+  {
+    "chinese": "知道",
+    "english": "know knows",
+    "soundmark": "/knew/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "forget forgets",
+    "soundmark": "/forgot/"
+  },
+  {
+    "chinese": "失去",
+    "english": "lose loses",
+    "soundmark": "/lost/"
+  },
+  {
+    "chinese": "离开",
+    "english": "leave leaves",
+    "soundmark": "/left/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "sleep sleeps",
+    "soundmark": "/slept/"
+  },
+  {
+    "chinese": "明白",
+    "english": "understand understands",
+    "soundmark": "/understood/"
+  },
+  {
+    "chinese": "买",
+    "english": "buy buys",
+    "soundmark": "/bought/"
+  },
+  {
+    "chinese": "洗",
+    "english": "wash washes",
+    "soundmark": "/washed/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "call calls",
+    "soundmark": "/called/"
+  },
+  {
+    "chinese": "帮助",
+    "english": "help helps",
+    "soundmark": "/helped/"
+  },
+  {
+    "chinese": "相信",
+    "english": "believe believes",
+    "soundmark": "/believed/"
+  },
+  {
+    "chinese": "学习",
+    "english": "study studies",
+    "soundmark": "/studied/"
+  },
+  {
+    "chinese": "解释",
+    "english": "explain explains",
+    "soundmark": "/explained/"
+  },
+  {
+    "chinese": "问",
+    "english": "ask asks",
+    "soundmark": "/asked/"
+  },
+  {
+    "chinese": "飞",
+    "english": "fly flies",
+    "soundmark": "/flew/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "read reads",
+    "soundmark": "/read/"
+  },
+  {
+    "chinese": "走路",
+    "english": "walk walks",
+    "soundmark": "/walked/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "dance dances",
+    "soundmark": "/danced/"
+  },
+  {
+    "chinese": "回答",
+    "english": "answer answers",
+    "soundmark": "/answered/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work works",
+    "soundmark": "/worked/"
+  },
+  {
+    "chinese": "待在",
+    "english": "stay stays",
+    "soundmark": "/stayed/"
+  },
+  {
+    "chinese": "支付",
+    "english": "pay pays",
+    "soundmark": "/paid/"
+  },
+  {
+    "chinese": "旅行",
+    "english": "travel travels",
+    "soundmark": "/traveled/"
+  },
+  {
+    "chinese": "给",
+    "english": "give gives",
+    "soundmark": "/gave/"
+  },
+  {
+    "chinese": "达到",
+    "english": "get gets",
+    "soundmark": "/got/"
+  },
+  {
+    "chinese": "锁",
+    "english": "lock locks",
+    "soundmark": "/locked/"
+  },
+  {
+    "chinese": "记得",
+    "english": "remember remembers",
+    "soundmark": "/remembered/"
+  },
+  {
+    "chinese": "清理",
+    "english": "clean cleans",
+    "soundmark": "/cleaned/"
+  },
+  {
+    "chinese": "找到",
+    "english": "find finds",
+    "soundmark": "/found/"
+  },
+  {
+    "chinese": "关闭",
+    "english": "close closes",
+    "soundmark": "/closed/"
+  },
+  {
+    "chinese": "教",
+    "english": "teach teaches",
+    "soundmark": "/taught/"
+  },
+  {
+    "chinese": "展示",
+    "english": "show shows",
+    "soundmark": "/showed/"
+  },
+  {
+    "chinese": "让",
+    "english": "let lets",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "休息",
+    "english": "rest rests",
+    "soundmark": "/rested/"
+  },
+  {
+    "chinese": "用",
+    "english": "use uses",
+    "soundmark": "/used/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "cook cooks",
+    "soundmark": "/cooked/"
+  },
+  {
+    "chinese": "去",
+    "english": "go goes",
+    "soundmark": "/went/"
+  },
+  {
+    "chinese": "决定",
+    "english": "decide decides",
+    "soundmark": "/decided/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "drive drives",
+    "soundmark": "/drove/"
+  },
+  {
+    "chinese": "改变",
+    "english": "change changes",
+    "soundmark": "/changed/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "try tries",
+    "soundmark": "/tried/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop stops",
+    "soundmark": "/Stopped/"
+  },
+  {
+    "chinese": "参加",
+    "english": "join joins",
+    "soundmark": "/joined/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "invite invites",
+    "soundmark": "/invited/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "refuse refuses",
+    "soundmark": "/refused/"
+  },
+  {
+    "chinese": "接受",
+    "english": "accept accepts",
+    "soundmark": "/accepted/"
+  },
+  {
+    "chinese": "学习",
+    "english": "learn learns",
+    "soundmark": "/learnt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "finish finishes",
+    "soundmark": "/finished/"
+  },
+  {
+    "chinese": "看",
+    "english": "watch watches",
+    "soundmark": "/watched/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "swim swims",
+    "soundmark": "/swam/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "master masters",
+    "soundmark": "/mastered/"
+  }
 ]


### PR DESCRIPTION
{
    "chinese": "在卧室里睡觉",
    "english": "to sleep in the bed room",
    "soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
  },

原先是 bed room 两个格子 

修复后： bedroom 应为一个单词