### PR TITLE
fix: set the drizzle config path

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,12 @@
 import type { Config } from "drizzle-kit";
+import path from 'path';
+import * as dotenv from 'dotenv';
+
+dotenv.config({
+  path: path.resolve(__dirname, "./apps/api/.env")
+});
+
+console.log("process.env.DATABASE_URL: ", process.env.DATABASE_URL);
 
 export default {
   schema: "libs/shared/src/schema/*",


### PR DESCRIPTION
drizzle-kit 连接库时，读取不到 `.env` 配置中的变量，导致 `db:init` 执行失败