### PR TITLE
fix: fix course-34 statement is incorrect

### DIFF
--- a/scripts/course/courses/34.json
+++ b/scripts/course/courses/34.json
@@ -700,7 +700,7 @@
 		"soundmark": "/baɪ/"
 	},
 	{
-		"chinese": "通过一个手头",
+		"chinese": "通过一个石头",
 		"english": "by a stone",
 		"soundmark": "/baɪ/ /ə/ /ston/"
 	},


### PR DESCRIPTION
错误描述：
{
		"chinese": "通过一个手头",
		"english": "by a stone",
		"soundmark": "/baɪ/ /ə/ /ston/"
	},
chinese： 通过一个手头 错误 。

修正：
        "chinese": "通过一个石头" 