### PR TITLE
fix: fix course issue, closes #118

### DIFF
--- a/scripts/course/courses/04.json
+++ b/scripts/course/courses/04.json
@@ -721,11 +721,11 @@
 	},
 	{
 		"chinese": "它不必",
-		"english": "it doesn't have to",
+		"english": "it doesn't have",
 		"soundmark": "/ɪt/ /ˈdʌznt/ /hæv/"
 	},
 	{
-		"chinese": "它不必现在在床上睡觉",
+		"chinese": "它不必在床上睡觉",
 		"english": "it doesn't have to sleep on the bed",
 		"soundmark": "/ɪt/ /ˈdʌznt/ /hæv/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
 	}


### PR DESCRIPTION
course-04错误描述以及修复：
1."english": "it doesn't have to",  to对应的下方音标“to"字段多余，进行删除
	{
		"chinese": "它不必",
		"english": "it doesn't have to",
		"soundmark": "/ɪt/ /ˈdʌznt/ /hæv/"
	},
2."chinese": "它不必现在在床上睡觉", “现在”这个时态多余，进行删除
	{
		"chinese": "它不必现在在床上睡觉",
		"english": "it doesn't have to sleep on the bed",
		"soundmark": "/ɪt/ /ˈdʌznt/ /hæv/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
	}

