### PR TITLE
fix: fix course-20 statement is incorrect

### DIFF
--- a/scripts/course/courses/20.json
+++ b/scripts/course/courses/20.json
@@ -205,7 +205,7 @@
 		"soundmark": "/maɪ/"
 	},
 	{
-		"chinese": "我的包",
+		"chinese": "我的书包",
 		"english": "my school bag",
 		"soundmark": "/maɪ/ /skul/ /bæɡ/"
 	},


### PR DESCRIPTION
错误描述：
chinese：我的包  -> 应为 ： 我的书包。 第一反应是my bag
{
		"chinese": "我的包",
		"english": "my school bag",
		"soundmark": "/maɪ/ /skul/ /bæɡ/"
	},

修正后： "chinese": "我的书包"