### PR TITLE
fix: update courses soundmark

### DIFF
--- a/scripts/course/courses/11.json
+++ b/scripts/course/courses/11.json
@@ -47,12 +47,12 @@
 	{
 		"chinese": "她现在想要做这件事",
 		"english": "she wants to do it now",
-		"soundmark": "/ʃi/ /wɑnts/ /tə/ /du/ /ɪt/ /naʊ/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
+		"soundmark": "/ʃi/ /wɑnts/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
 	{
 		"chinese": "她现在不想做这件事",
 		"english": "she doesn't want to do it now",
-		"soundmark": "/ʃi/ /ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/ʃi/ /ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
 	{
 		"chinese": "我（过去）想要做这件事情",
@@ -67,7 +67,7 @@
 	{
 		"chinese": "我昨天想要做这件事情",
 		"english": "I wanted to do it yesterday",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/ /'jɛstɚde/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/ /'jɛstɚde/"
 	},
 	{
 		"chinese": "我昨天不想做这件事情",
@@ -117,12 +117,12 @@
 	{
 		"chinese": "我不喜欢每天待在那里",
 		"english": "I don't like to stay there every day",
-		"soundmark": "/aɪ/ /dont/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/ /（过去）喜欢 liked/ /laikt/"
+		"soundmark": "/aɪ/ /dont/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/"
 	},
 	{
 		"chinese": "我（过去）喜欢待在那里",
 		"english": "I liked to stay there",
-		"soundmark": "/aɪ/ /laikt/ /tə/ /ste/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /laikt/ /tə/ /ste/ /ðɛr/"
 	},
 	{
 		"chinese": "我（过去）不喜欢待在那里",
@@ -192,7 +192,7 @@
 	{
 		"chinese": "我必须在那时离开这座城市",
 		"english": "I had to leave the city at that time",
-		"soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/"
 	},
 	{
 		"chinese": "我不必在那时离开这座城市",
@@ -227,12 +227,12 @@
 	{
 		"chinese": "我不打算去那里",
 		"english": "I don't plan to get there",
-		"soundmark": "/aɪ/ /dont/ /plæn/ /tə/ /ɡɛt/ /ðɛr/ /（过去）打算 planned/ /plænd/"
+		"soundmark": "/aɪ/ /dont/ /plæn/ /tə/ /ɡɛt/ /ðɛr/"
 	},
 	{
 		"chinese": "我（过去）打算去那里",
 		"english": "I planned to get there",
-		"soundmark": "/aɪ/ /plænd/ /tə/ /ɡɛt/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /plænd/ /tə/ /ɡɛt/ /ðɛr/"
 	},
 	{
 		"chinese": "我（过去）不打算去那里",
@@ -277,12 +277,12 @@
 	{
 		"chinese": "我不需要知道真相",
 		"english": "I don't need to know the truth",
-		"soundmark": "/aɪ/ /dont/ /nid/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
+		"soundmark": "/aɪ/ /dont/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
 	},
 	{
 		"chinese": "我（过去）需要知道真相",
 		"english": "I needed to know the truth",
-		"soundmark": "/aɪ/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
 	},
 	{
 		"chinese": "我（过去）不需要知道真相",
@@ -292,7 +292,7 @@
 	{
 		"chinese": "她（过去）需要知道真相",
 		"english": "she needed to know the truth",
-		"soundmark": "/ʃi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ʃi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
 	},
 	{
 		"chinese": "她（过去）不需要知道真相",
@@ -322,7 +322,7 @@
 	{
 		"chinese": "你现在不做这件事情",
 		"english": "you don't do it now",
-		"soundmark": "/ju/ /dont/ /du/ /ɪt/ /naʊ/ /（过去）做 did/ /dɪd/"
+		"soundmark": "/ju/ /dont/ /du/ /ɪt/ /naʊ/"
 	},
 	{
 		"chinese": "你（过去）做这件事情",
@@ -347,7 +347,7 @@
 	{
 		"chinese": "你去年做这件事情",
 		"english": "you did it last year",
-		"soundmark": "/ju/ /dɪd/ /ɪt/ /læst/ /jɪr/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /dɪd/ /ɪt/ /læst/ /jɪr/"
 	},
 	{
 		"chinese": "你去年没做这件事情",
@@ -382,17 +382,17 @@
 	{
 		"chinese": "她告诉我",
 		"english": "she tells me",
-		"soundmark": "/ʃi/ /tɛlz/ /mi/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
+		"soundmark": "/ʃi/ /tɛlz/ /mi/"
 	},
 	{
 		"chinese": "她不告诉我",
 		"english": "she doesn't tell me",
-		"soundmark": "/ʃi/ /ˈdʌznt/ /tɛl/ /mi/ /（过去）告诉 told/ /told/ /（过去）告诉我 told me/ /told/ /mi/"
+		"soundmark": "/ʃi/ /ˈdʌznt/ /tɛl/ /mi/"
 	},
 	{
 		"chinese": "他（过去）告诉我",
 		"english": "he told me",
-		"soundmark": "/hi/ /told/ /mi/ /（过去）不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/hi/ /told/ /mi/"
 	},
 	{
 		"chinese": "他（过去）没告诉我",
@@ -407,7 +407,7 @@
 	{
 		"chinese": "他（过去）没告诉我真相",
 		"english": "he didn't tell me the truth",
-		"soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
+		"soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/ /ðə/ /trʊθ/"
 	},
 	{
 		"chinese": "知道",
@@ -482,7 +482,7 @@
 	{
 		"chinese": "成为一个老师",
 		"english": "to be a teacher",
-		"soundmark": "/tə/ /bi/ /ə/ /'titʃɚ/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/tə/ /bi/ /ə/ /'titʃɚ/"
 	},
 	{
 		"chinese": "我（过去）想要成为一个老师",
@@ -542,7 +542,7 @@
 	{
 		"chinese": "交谈；聊天",
 		"english": "to talk",
-		"soundmark": "/tə/ /tɔk/ /（过去）聊天 talked/ /tɔkt/"
+		"soundmark": "/tə/ /tɔk/"
 	},
 	{
 		"chinese": "我们（过去）聊天",

--- a/scripts/course/courses/12.json
+++ b/scripts/course/courses/12.json
@@ -122,7 +122,7 @@
 	{
 		"chinese": "见到",
 		"english": "to see",
-		"soundmark": "/tə/ /si/ /（过去）见到 saw/ /sɔ/"
+		"soundmark": "/tə/ /si/"
 	},
 	{
 		"chinese": "我（过去）见到你",
@@ -312,7 +312,7 @@
 	{
 		"chinese": "知道",
 		"english": "to know",
-		"soundmark": "/tə/ /no/ /（过去）知道 knew/ /nju/ /（过去）知道答案 knew the answer/ /nju/ /ði/ /'ænsɚ/"
+		"soundmark": "/tə/ /no/"
 	},
 	{
 		"chinese": "他（过去）知道答案",
@@ -347,7 +347,7 @@
 	{
 		"chinese": "忘记",
 		"english": "to forget",
-		"soundmark": "/tə/ /fɚ'ɡɛt/ /（过去）忘记 forgot/ /fɚ'ɡɑt/"
+		"soundmark": "/tə/ /fɚ'ɡɛt/"
 	},
 	{
 		"chinese": "告诉",
@@ -482,7 +482,7 @@
 	{
 		"chinese": "睡觉",
 		"english": "to sleep",
-		"soundmark": "/tə/ /slip/ /（过去）睡觉 slept/ /slɛpt/"
+		"soundmark": "/tə/ /slip/"
 	},
 	{
 		"chinese": "房间",
@@ -542,7 +542,7 @@
 	{
 		"chinese": "你不明白",
 		"english": "you don't understand",
-		"soundmark": "/ju/ /dont/ /ʌndɚ'stænd/ /（过去）明白 understood/ /ʌndɚˈstʊd/"
+		"soundmark": "/ju/ /dont/ /ʌndɚ'stænd/"
 	},
 	{
 		"chinese": "你（过去）明白",

--- a/scripts/course/courses/13.json
+++ b/scripts/course/courses/13.json
@@ -22,7 +22,7 @@
 	{
 		"chinese": "付钱给他",
 		"english": "to pay him",
-		"soundmark": "/tə/ /pe/ /hɪm/ /(过去)付钱 paid/ /ped/ /(过去)付钱给他 paid him/ /ped/ /hɪm/"
+		"soundmark": "/tə/ /pe/ /hɪm/"
 	},
 	{
 		"chinese": "你",
@@ -202,7 +202,7 @@
 	{
 		"chinese": "我开那辆车",
 		"english": "I drive the car",
-		"soundmark": "/aɪ/ /draɪv/ /ðə/ /kɑr/ /(过去)驾驶 drove/ /drov/"
+		"soundmark": "/aɪ/ /draɪv/ /ðə/ /kɑr/"
 	},
 	{
 		"chinese": "我(过去)开那辆车",
@@ -257,7 +257,7 @@
 	{
 		"chinese": "你不相信我",
 		"english": "you don't believe me",
-		"soundmark": "/ju/ /dont/ /bɪ'liv/ /mi/ /(过去)相信 believed/ /bɪ'livd/"
+		"soundmark": "/ju/ /dont/ /bɪ'liv/ /mi/"
 	},
 	{
 		"chinese": "你(过去)相信我",
@@ -347,7 +347,7 @@
 	{
 		"chinese": "决定",
 		"english": "to decide",
-		"soundmark": "/tə/ /dɪ'saɪd/ /(过去)决定 decided/ /dɪ'saɪdɪd/"
+		"soundmark": "/tə/ /dɪ'saɪd/"
 	},
 	{
 		"chinese": "开那辆车",
@@ -392,7 +392,7 @@
 	{
 		"chinese": "我不尝试开那辆车",
 		"english": "I don't try to drive the car",
-		"soundmark": "/aɪ/ /dont/ /traɪ/ /tə/ /draɪv/ /ðə/ /kɑr/ /(过去)尝试 tried/ /traɪd/"
+		"soundmark": "/aɪ/ /dont/ /traɪ/ /tə/ /draɪv/ /ðə/ /kɑr/"
 	},
 	{
 		"chinese": "我(过去)尝试开那辆车",
@@ -412,7 +412,7 @@
 	{
 		"chinese": "我不开那辆车",
 		"english": "I don't drive the car",
-		"soundmark": "/aɪ/ /dont/ /draɪv/ /ðə/ /kɑr/ /(过去)驾驶 drove/ /drov/"
+		"soundmark": "/aɪ/ /dont/ /draɪv/ /ðə/ /kɑr/"
 	},
 	{
 		"chinese": "我(过去)开那辆车",
@@ -507,7 +507,7 @@
 	{
 		"chinese": "我找到一个方法阻止他",
 		"english": "I find a way to stop him",
-		"soundmark": "/aɪ/ /faɪnd/ /ə/ /we/ /tə/ /stɑp/ /hɪm/ /(过去)找到 found/ /faʊnd/"
+		"soundmark": "/aɪ/ /faɪnd/ /ə/ /we/ /tə/ /stɑp/ /hɪm/"
 	},
 	{
 		"chinese": "我(过去)找到一个方法阻止他",
@@ -522,7 +522,7 @@
 	{
 		"chinese": "我阻止他",
 		"english": "I stop him",
-		"soundmark": "/aɪ/ /stɑp/ /hɪm/ /(过去)阻止 stopped/ /stɑpt/"
+		"soundmark": "/aɪ/ /stɑp/ /hɪm/"
 	},
 	{
 		"chinese": "我阻止了他",

--- a/scripts/course/courses/14.json
+++ b/scripts/course/courses/14.json
@@ -52,7 +52,7 @@
 	{
 		"chinese": "我们不想邀请她参加聚会",
 		"english": "we don't want to invite her to join the party",
-		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /'ɪnvaɪt/ /hɚ/ /tə/ /dʒɔɪn/ /ðə/ /'pɑrti/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /'ɪnvaɪt/ /hɚ/ /tə/ /dʒɔɪn/ /ðə/ /'pɑrti/"
 	},
 	{
 		"chinese": "我们（过去）想要邀请她参加聚会",
@@ -87,7 +87,7 @@
 	{
 		"chinese": "我们经常邀请她参加聚会",
 		"english": "we often invite her to join the party",
-		"soundmark": "/wi/ /'ɔfn/ /'ɪnvaɪt/ /hɚ/ /tə/ /dʒɔɪn/ /ðə/ /'pɑrti/ /（过去）邀请 invited/ /ɪn'vaɪtɪd/"
+		"soundmark": "/wi/ /'ɔfn/ /'ɪnvaɪt/ /hɚ/ /tə/ /dʒɔɪn/ /ðə/ /'pɑrti/"
 	},
 	{
 		"chinese": "我们（过去）邀请她参加聚会",
@@ -122,7 +122,7 @@
 	{
 		"chinese": "她想要加入我们",
 		"english": "she wants to join us",
-		"soundmark": "/ʃi/ /wɑnts/ /tə/ /dʒɔɪn/ /ʌs/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/ʃi/ /wɑnts/ /tə/ /dʒɔɪn/ /ʌs/"
 	},
 	{
 		"chinese": "她（过去）想要加入我们",
@@ -172,7 +172,7 @@
 	{
 		"chinese": "拒绝",
 		"english": "to refuse",
-		"soundmark": "/tə/ /ri'fjuz/ /（过去）拒绝 refused/ /ri'fjuzd/"
+		"soundmark": "/tə/ /ri'fjuz/"
 	},
 	{
 		"chinese": "她（过去）拒绝",
@@ -217,7 +217,7 @@
 	{
 		"chinese": "她有足够的时间",
 		"english": "she has enough time",
-		"soundmark": "/ʃi/ /hæz/ /ɪ'nʌf/ /taɪm/ /（过去）拥有 had/ /hæd/"
+		"soundmark": "/ʃi/ /hæz/ /ɪ'nʌf/ /taɪm/"
 	},
 	{
 		"chinese": "她（过去）有足够的时间",
@@ -272,7 +272,7 @@
 	{
 		"chinese": "他拒绝承担责任",
 		"english": "he refuses to accept the responsibility",
-		"soundmark": "/hi/ /ri'fjuzɪz/ /tə/ /ək'sɛpt/ /ðə/ /rɪspɑnsə'bɪləti/ /（过去）拒绝 refused/ /ri'fjuzd/"
+		"soundmark": "/hi/ /ri'fjuzɪz/ /tə/ /ək'sɛpt/ /ðə/ /rɪspɑnsə'bɪləti/"
 	},
 	{
 		"chinese": "他（过去）拒绝承担责任",
@@ -347,7 +347,7 @@
 	{
 		"chinese": "我真的不想学习如何开车",
 		"english": "I really don't want to learn how to drive",
-		"soundmark": "/aɪ/ /'rili/ /dont/ /wɑnt/ /tə/ /lɝn/ /haʊ/ /tə/ /draɪv/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/aɪ/ /'rili/ /dont/ /wɑnt/ /tə/ /lɝn/ /haʊ/ /tə/ /draɪv/"
 	},
 	{
 		"chinese": "我真的（过去）想要学习如何开车",
@@ -472,7 +472,7 @@
 	{
 		"chinese": "我只是想要完成我的工作",
 		"english": "I just want to finish my work",
-		"soundmark": "/aɪ/ /dʒʌst/ /wɑnt/ /tə/ /'fɪnɪʃ/ /maɪ/ /wɝk/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/aɪ/ /dʒʌst/ /wɑnt/ /tə/ /'fɪnɪʃ/ /maɪ/ /wɝk/"
 	},
 	{
 		"chinese": "我只是（过去）想要完成我的工作",
@@ -547,7 +547,7 @@
 	{
 		"chinese": "我不想看那个电影",
 		"english": "I don't want to watch the movie",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /wɔtʃ/ /ðə/ /'muvi/ /（过去）想要 wanted/ /wɑntɪd/"
+		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /wɔtʃ/ /ðə/ /'muvi/"
 	},
 	{
 		"chinese": "我（过去）想要看一个电影",

--- a/scripts/course/courses/15.5.json
+++ b/scripts/course/courses/15.5.json
@@ -57,17 +57,17 @@
 	{
 		"chinese": "我在厨房里（现在）正在吃鸡蛋",
 		"english": "I am eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
 		"chinese": "我在厨房里（过去）正在吃鸡蛋",
 		"english": "I was eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
+		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
 		"chinese": "你在厨房里（现在）正在吃鸡蛋",
 		"english": "you are eating eggs in the kitchen",
-		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
+		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
 		"chinese": "你在厨房里（过去）正在吃鸡蛋",
@@ -77,12 +77,12 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "他们在厨房里（现在）正在吃鸡蛋",
 		"english": "they are eating eggs in the kitchen",
-		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
+		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
 		"chinese": "他们在厨房里（过去）正在吃鸡蛋",
@@ -117,7 +117,7 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "他们（现在）正在喝茶",
@@ -217,12 +217,12 @@
 	{
 		"chinese": "正在教我们如何说英语",
 		"english": "teaching us how to speak English",
-		"soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
+		"soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
 	},
 	{
 		"chinese": "星荣正在教我们如何说英语",
 		"english": "Xingrong is teaching us how to speak English",
-		"soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
+		"soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
 	},
 	{
 		"chinese": "星荣（过去）正在教我们如何说英语",
@@ -252,7 +252,7 @@
 	{
 		"chinese": "正在学习英语",
 		"english": "learning English",
-		"soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
+		"soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
 	},
 	{
 		"chinese": "我正在学习英语",
@@ -312,7 +312,7 @@
 	{
 		"chinese": "我正在通过观看他的视频的方式学习英语",
 		"english": "I am learning English by watching his videos",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
 	},
 	{
 		"chinese": "我（过去）正在通过观看他的视频的方式学习英语",
@@ -372,12 +372,12 @@
 	{
 		"chinese": "正在从学校走路回家",
 		"english": "walking home from school",
-		"soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
+		"soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
 	},
 	{
 		"chinese": "我正在从学校走路回家",
 		"english": "I am walking home from school",
-		"soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
 	},
 	{
 		"chinese": "我（过去）正在从学校走路回家",
@@ -407,7 +407,7 @@
 	{
 		"chinese": "遇见一个老朋友",
 		"english": "to meet an old friend",
-		"soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
+		"soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/"
 	},
 	{
 		"chinese": "我（过去）遇见一个老朋友",
@@ -462,12 +462,12 @@
 	{
 		"chinese": "正在在卧室里睡觉",
 		"english": "sleeping in the bedroom",
-		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
+		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
 		"chinese": "我正在在卧室里睡觉",
 		"english": "I am sleeping in the bedroom",
-		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
 		"chinese": "我（过去）正在在卧室里睡觉",
@@ -482,7 +482,7 @@
 	{
 		"chinese": "打电话给我",
 		"english": "to call me",
-		"soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
+		"soundmark": "/tə/ /kɔl/ /mi/"
 	},
 	{
 		"chinese": "她",
@@ -537,12 +537,12 @@
 	{
 		"chinese": "正在弹钢琴",
 		"english": "playing the piano",
-		"soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
+		"soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/"
 	},
 	{
 		"chinese": "她正在弹钢琴",
 		"english": "she is playing the piano",
-		"soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
+		"soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
 	},
 	{
 		"chinese": "她（过去）正在弹钢琴",

--- a/scripts/course/courses/16.json
+++ b/scripts/course/courses/16.json
@@ -47,7 +47,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /（I，现在时）be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我（现在）正在阅读一本英语书",
@@ -67,7 +67,7 @@
 	{
 		"chinese": "我此刻正在阅读一本英语书",
 		"english": "I am reading an English book at the moment",
-		"soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /æt/ /ðə/ /'momənt/ /（I，过去时）be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "我（过去）正在阅读一本英语书",
@@ -142,7 +142,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她（现在）正在做她的家庭作业",
@@ -177,7 +177,7 @@
 	{
 		"chinese": "我的女儿此刻正在做她的家庭作业",
 		"english": "my daughter is doing her homework at the moment",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "我的女儿（过去）正在做她的家庭作业",
@@ -242,7 +242,7 @@
 	{
 		"chinese": "他",
 		"english": "he",
-		"soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
+		"soundmark": "/hi/"
 	},
 	{
 		"chinese": "他（现在）正在在街上跑步",
@@ -257,7 +257,7 @@
 	{
 		"chinese": "他此刻正在在街上跑步",
 		"english": "he is running in the street at the moment",
-		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
+		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "他（过去）正在在街上跑步",
@@ -307,7 +307,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她（现在）正在游泳池里游泳",
@@ -322,7 +322,7 @@
 	{
 		"chinese": "她此刻正在游泳池里游泳",
 		"english": "she is swimming in the pool at the moment",
-		"soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/ /æt/ /ðə/ /moment/ /'momənt/ /（she，过去时）be was/ /wəz/"
+		"soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/ /æt/ /ðə/ /moment/ /'momənt/"
 	},
 	{
 		"chinese": "她（过去）正在游泳池里游泳",
@@ -392,7 +392,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她（现在）正在做家务",
@@ -427,7 +427,7 @@
 	{
 		"chinese": "我妈此刻正在做家务",
 		"english": "my mother is doing the housework at the moment",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+		"soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "我妈（过去）正在做家务",
@@ -477,7 +477,7 @@
 	{
 		"chinese": "他",
 		"english": "he",
-		"soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
+		"soundmark": "/hi/"
 	},
 	{
 		"chinese": "他（现在）正在手机上说话",
@@ -512,7 +512,7 @@
 	{
 		"chinese": "我爸此刻正在手机上说话",
 		"english": "my father is talking on the phone at the moment",
-		"soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
+		"soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "我爸（过去）正在手机上说话",
@@ -572,7 +572,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她（现在）正在看电视",
@@ -602,7 +602,7 @@
 	{
 		"chinese": "我女儿此刻正在看电视",
 		"english": "my daughter is watching TV at the moment",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "我女儿（过去）正在看电视",
@@ -672,7 +672,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她（现在）正在做牛肉烧土豆",
@@ -707,7 +707,7 @@
 	{
 		"chinese": "她妈妈此刻正在做牛肉烧土豆",
 		"english": "her mother is cooking beef with potatoes at the moment",
-		"soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+		"soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/ /æt/ /ðə/ /'momənt/"
 	},
 	{
 		"chinese": "她妈妈（过去）正在做牛肉烧土豆",

--- a/scripts/course/courses/17.json
+++ b/scripts/course/courses/17.json
@@ -97,7 +97,7 @@
 	{
 		"chinese": "我们",
 		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/"
 	},
 	{
 		"chinese": "我们(现在)正在购物",
@@ -122,7 +122,7 @@
 	{
 		"chinese": "我们现在正在在超市购物",
 		"english": "we are shopping at the supermarket now",
-		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /naʊ/ /(we，过去时)be were/ /wɚ/"
+		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /naʊ/"
 	},
 	{
 		"chinese": "我们(过去)正在在超市购物",
@@ -132,12 +132,12 @@
 	{
 		"chinese": "打电话",
 		"english": "to call",
-		"soundmark": "/tə/ /kɔl/ /(过去)打电话 called/ /kɔld/"
+		"soundmark": "/tə/ /kɔl/"
 	},
 	{
 		"chinese": "我",
 		"english": "me",
-		"soundmark": "/mi/ /(过去)打电话给我 called me/ /kɔld/ /mi/"
+		"soundmark": "/mi/"
 	},
 	{
 		"chinese": "你(过去)打电话给我",
@@ -187,7 +187,7 @@
 	{
 		"chinese": "我们(过去)正在购物",
 		"english": "we were shopping",
-		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/"
 	},
 	{
 		"chinese": "我们(现在)正在购物",
@@ -302,7 +302,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我(现在)正在等待",
@@ -357,7 +357,7 @@
 	{
 		"chinese": "我现在在公交车站正在为了我的朋友等待",
 		"english": "I am waiting for my friend at the bus stop now",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /naʊ/ /(I，过去时)be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /naʊ/"
 	},
 	{
 		"chinese": "我在公交车站(过去)正在为了我的朋友等待",
@@ -452,7 +452,7 @@
 	{
 		"chinese": "我(过去)正在为了我的朋友等待",
 		"english": "I was waiting for my friend",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
 		"chinese": "我(现在)正在为了我的朋友等待",
@@ -792,7 +792,7 @@
 	{
 		"chinese": "问题",
 		"english": "that question",
-		"soundmark": "/ðæt/ /'kwɛstʃən/ /(I，过去时)be was/ /wəz/"
+		"soundmark": "/ðæt/ /'kwɛstʃən/"
 	},
 	{
 		"chinese": "我(过去)正在等你问我那个问题",

--- a/scripts/course/courses/18.json
+++ b/scripts/course/courses/18.json
@@ -7,7 +7,7 @@
 	{
 		"chinese": "注意力",
 		"english": "attention",
-		"soundmark": "/ə'tɛnʃən/ /(付出注意力)注意 to pay attention/ /tə/ /pe/ /ə'tɛnʃən/"
+		"soundmark": "/ə'tɛnʃən/"
 	},
 	{
 		"chinese": "需要",
@@ -67,12 +67,12 @@
 	{
 		"chinese": "你不需要注意这个问题",
 		"english": "you don't need to pay attention to this question",
-		"soundmark": "/ju/ /dont/ /nid/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /'kwɛstʃən/ /(过去)需要 needed/ /nidɪd/"
+		"soundmark": "/ju/ /dont/ /nid/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /'kwɛstʃən/"
 	},
 	{
 		"chinese": "你(过去)需要注意这个问题",
 		"english": "you needed to pay attention to this question",
-		"soundmark": "/ju/ /nidɪd/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /'kwɛstʃən/ /(过去)不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /nidɪd/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /'kwɛstʃən/"
 	},
 	{
 		"chinese": "你(过去)不需要注意这个问题",
@@ -117,17 +117,17 @@
 	{
 		"chinese": "你没有注意这个信息",
 		"english": "you don't pay attention to this information",
-		"soundmark": "/ju/ /dont/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/ /(过去)付出 paid/ /ped/"
+		"soundmark": "/ju/ /dont/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
 		"chinese": "注意力",
 		"english": "attention",
-		"soundmark": "/ə'tɛnʃən/ /(过去)付出注意力 paid attention/ /ped/ /ə'tɛnʃən/"
+		"soundmark": "/ə'tɛnʃən/"
 	},
 	{
 		"chinese": "你(过去)注意这个信息",
 		"english": "you paid attention to this information",
-		"soundmark": "/ju/ /ped/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/ /(过去)不 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /ped/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
 		"chinese": "你(过去)没有注意这个信息",
@@ -202,7 +202,7 @@
 	{
 		"chinese": "你",
 		"english": "you",
-		"soundmark": "/ju/ /(you，现在时)be are/ /ɚ/"
+		"soundmark": "/ju/"
 	},
 	{
 		"chinese": "你(现在)正在注意这个信息",
@@ -212,7 +212,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我(现在)正在注意这个信息",
@@ -222,7 +222,7 @@
 	{
 		"chinese": "他",
 		"english": "he",
-		"soundmark": "/hi/ /(he，现在时)be is/ /ɪz/"
+		"soundmark": "/hi/"
 	},
 	{
 		"chinese": "他(现在)正在注意这个信息",
@@ -237,7 +237,7 @@
 	{
 		"chinese": "他(现在)没有正在注意这个信息",
 		"english": "he is not paying attention to this information",
-		"soundmark": "/hi/ /ɪz/ /nɑt/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/ /(he，过去时)be was/ /wəz/"
+		"soundmark": "/hi/ /ɪz/ /nɑt/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
 		"chinese": "他(过去)正在注意这个信息",
@@ -597,7 +597,7 @@
 	{
 		"chinese": "正在一起讨论这个计划的所有细节",
 		"english": "be discussing all the details of the plan together",
-		"soundmark": "/bi/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/bi/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
 	{
 		"chinese": "我们(现在)正在讨论",
@@ -622,7 +622,7 @@
 	{
 		"chinese": "我们(现在)正在一起讨论这个计划的所有的细节",
 		"english": "we are discussing all the details of the plan together",
-		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/ /(we，过去时)be were/ /wɚ/"
+		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
 	{
 		"chinese": "我们(过去)正在一起讨论这个计划的所有的细节",

--- a/scripts/course/courses/19.json
+++ b/scripts/course/courses/19.json
@@ -142,7 +142,7 @@
 	{
 		"chinese": "我们",
 		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/"
 	},
 	{
 		"chinese": "我们(现在)正在尝试",
@@ -252,7 +252,7 @@
 	{
 		"chinese": "我们",
 		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/"
 	},
 	{
 		"chinese": "我们(现在)正在面对",
@@ -327,7 +327,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我(现在)正在尝试",
@@ -362,7 +362,7 @@
 	{
 		"chinese": "我们",
 		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/"
 	},
 	{
 		"chinese": "我们(现在)正在面对",
@@ -612,7 +612,7 @@
 	{
 		"chinese": "正在疑惑",
 		"english": "be wondering",
-		"soundmark": "/bi/ /'wʌndərɪŋ/ /(I，过去时)be was/ /wəz/"
+		"soundmark": "/bi/ /'wʌndərɪŋ/"
 	},
 	{
 		"chinese": "我(过去)正在疑惑",
@@ -662,7 +662,7 @@
 	{
 		"chinese": "他",
 		"english": "he",
-		"soundmark": "/hi/ /(he，现在时)be is/ /ɪz/"
+		"soundmark": "/hi/"
 	},
 	{
 		"chinese": "他(现在)正在疑惑",

--- a/scripts/course/courses/20.5.json
+++ b/scripts/course/courses/20.5.json
@@ -167,7 +167,7 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /(they，现在时)be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "看(ing形式)",
@@ -397,7 +397,7 @@
 	{
 		"chinese": "你",
 		"english": "you",
-		"soundmark": "/ju/ /(you，现在时)be are/ /ɚ/"
+		"soundmark": "/ju/"
 	},
 	{
 		"chinese": "你(现在)正在寻找",
@@ -517,12 +517,12 @@
 	{
 		"chinese": "听见；听说",
 		"english": "to hear",
-		"soundmark": "/tə/ /hɪr/ /(过去)听说 heard/ /hɚd/"
+		"soundmark": "/tə/ /hɪr/"
 	},
 	{
 		"chinese": "我(过去)听说",
 		"english": "I heard",
-		"soundmark": "/aɪ/ /hɚd/ /(you，过去时)be were/ /wɚ/"
+		"soundmark": "/aɪ/ /hɚd/"
 	},
 	{
 		"chinese": "你(过去)正在寻找我",

--- a/scripts/course/courses/21.json
+++ b/scripts/course/courses/21.json
@@ -82,7 +82,7 @@
 	{
 		"chinese": "正在工作",
 		"english": "be working",
-		"soundmark": "/bi/ /'wɝkɪŋ/ /(he，现在时)be is/ /ɪz/"
+		"soundmark": "/bi/ /'wɝkɪŋ/"
 	},
 	{
 		"chinese": "他(现在)正在工作",
@@ -112,7 +112,7 @@
 	{
 		"chinese": "正在工作",
 		"english": "be working",
-		"soundmark": "/bi/ /'wɝkɪŋ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/bi/ /'wɝkɪŋ/"
 	},
 	{
 		"chinese": "我(现在)正在工作",
@@ -152,7 +152,7 @@
 	{
 		"chinese": "我们",
 		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/wi/"
 	},
 	{
 		"chinese": "我们(现在)正在在那件事上工作",
@@ -262,7 +262,7 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /(she，现在时)be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她(现在)正在寻找",
@@ -392,12 +392,12 @@
 	{
 		"chinese": "我的女儿(现在)正在寻找她的玩具但是她不能找到它",
 		"english": "my daughter is looking for her toy but she can't find it",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /bʌt/ /ʃi/ /kænt/ /faɪnd/ /ɪt/ /(she，过去时)be was/ /wəz/"
+		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /bʌt/ /ʃi/ /kænt/ /faɪnd/ /ɪt/"
 	},
 	{
 		"chinese": "我的女儿(过去)正在寻找她的玩具",
 		"english": "my daughter was looking for her toy",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /(过去)能 could/ /kʊd/ /(过去)不能 couldn't/ /kʊdnt/"
+		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/"
 	},
 	{
 		"chinese": "但是她(过去)不能找到它",
@@ -537,7 +537,7 @@
 	{
 		"chinese": "听(ing形式)",
 		"english": "listening",
-		"soundmark": "/ˈlɪsnɪŋ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/ˈlɪsnɪŋ/"
 	},
 	{
 		"chinese": "我(现在)正在听",
@@ -557,12 +557,12 @@
 	{
 		"chinese": "她",
 		"english": "she",
-		"soundmark": "/ʃi/ /(she，现在时)be is/ /ɪz/"
+		"soundmark": "/ʃi/"
 	},
 	{
 		"chinese": "她(现在)正在听音乐",
 		"english": "she is listening to music",
-		"soundmark": "/ʃi/ /ɪz/ /ˈlɪsnɪŋ/ /tə/ /'mjuzɪk/ /(she，过去时)be was/ /wəz/"
+		"soundmark": "/ʃi/ /ɪz/ /ˈlɪsnɪŋ/ /tə/ /'mjuzɪk/"
 	},
 	{
 		"chinese": "她(过去)正在听音乐",
@@ -587,7 +587,7 @@
 	{
 		"chinese": "我(过去)正在听一些音乐",
 		"english": "I was listening to some music",
-		"soundmark": "/aɪ/ /wəz/ /ˈlɪsnɪŋ/ /tə/ /səm/ /'mjuzɪk/ /(you，现在时)be are/ /ɚ/"
+		"soundmark": "/aɪ/ /wəz/ /ˈlɪsnɪŋ/ /tə/ /səm/ /'mjuzɪk/"
 	},
 	{
 		"chinese": "你(现在)正在听",

--- a/scripts/course/courses/22.json
+++ b/scripts/course/courses/22.json
@@ -437,7 +437,7 @@
 	{
 		"chinese": "说",
 		"english": "to say",
-		"soundmark": "/tə/ /se/"
+		"soundmark": "/tə/ /seɪ/"
 	},
 	{
 		"chinese": "它；那句话",
@@ -447,7 +447,7 @@
 	{
 		"chinese": "说那句话",
 		"english": "to say it",
-		"soundmark": "/tə/ /se/ /ɪt/"
+		"soundmark": "/tə/ /seɪ/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)为什么",
@@ -457,7 +457,7 @@
 	{
 		"chinese": "你(过去)为什么说那句话？",
 		"english": "why did you say it",
-		"soundmark": "/waɪ/ /dɪd/ /ju/ /se/ /ɪt/"
+		"soundmark": "/waɪ/ /dɪd/ /ju/ /seɪ/ /ɪt/"
 	},
 	{
 		"chinese": "到达",
@@ -642,7 +642,7 @@
 	{
 		"chinese": "说",
 		"english": "to say",
-		"soundmark": "/tə/ /se/"
+		"soundmark": "/tə/ /seɪ/"
 	},
 	{
 		"chinese": "你(过去)......了什么",
@@ -652,7 +652,7 @@
 	{
 		"chinese": "你(过去)说了什么？",
 		"english": "what did you say",
-		"soundmark": "/wɑt/ /dɪd/ /ju/ /se/"
+		"soundmark": "/wɑt/ /dɪd/ /ju/ /seɪ/"
 	},
 	{
 		"chinese": "学",

--- a/scripts/course/courses/22.json
+++ b/scripts/course/courses/22.json
@@ -122,7 +122,7 @@
 	{
 		"chinese": "你有听见我吗？",
 		"english": "do you hear me",
-		"soundmark": "/du/ /ju/ /hɪr/ /mi/ /do过去式 did/ /dɪd/"
+		"soundmark": "/du/ /ju/ /hɪr/ /mi/"
 	},
 	{
 		"chinese": "你(过去)有听见我吗？",
@@ -172,7 +172,7 @@
 	{
 		"chinese": "你没有做这件事",
 		"english": "you don't do it",
-		"soundmark": "/ju/ /dont/ /du/ /ɪt/ /(过去)没有 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /dont/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)没有做这件事",

--- a/scripts/course/courses/23.json
+++ b/scripts/course/courses/23.json
@@ -257,7 +257,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我(现在)正在操作",
@@ -382,7 +382,7 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /(they，现在时)be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "他们(现在)正在处理",
@@ -437,7 +437,7 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /(they，现在时)be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "他们(现在)正在面对",

--- a/scripts/course/courses/24.json
+++ b/scripts/course/courses/24.json
@@ -77,7 +77,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我（现在）正在牵着",
@@ -627,7 +627,7 @@
 	{
 		"chinese": "决定",
 		"english": "to decide",
-		"soundmark": "/tə/ /dɪ'saɪd/ /（过去）决定 decided/ /dɪ'saɪdɪd/"
+		"soundmark": "/tə/ /dɪ'saɪd/"
 	},
 	{
 		"chinese": "他们",
@@ -672,7 +672,7 @@
 	{
 		"chinese": "他们",
 		"english": "they",
-		"soundmark": "/ðe/ /(they，现在时)be are/ /ɚ/"
+		"soundmark": "/ðe/"
 	},
 	{
 		"chinese": "他们(现在)正在面对",

--- a/scripts/course/courses/26.json
+++ b/scripts/course/courses/26.json
@@ -372,7 +372,7 @@
 	{
 		"chinese": "正在做",
 		"english": "be making",
-		"soundmark": "/bi/ /'mekɪŋ/ /(we，现在时)be are/ /ɚ/"
+		"soundmark": "/bi/ /'mekɪŋ/"
 	},
 	{
 		"chinese": "我们正在做",
@@ -642,7 +642,7 @@
 	{
 		"chinese": "我们决定做改变",
 		"english": "we decide to make a change",
-		"soundmark": "/wi/ /dɪ'saɪd/ /tə/ /mek/ /ə/ /tʃendʒ/ /（过去）决定 decided/ /dɪ'saɪdɪd/"
+		"soundmark": "/wi/ /dɪ'saɪd/ /tə/ /mek/ /ə/ /tʃendʒ/"
 	},
 	{
 		"chinese": "我们（过去）决定做改变",

--- a/scripts/course/courses/27.json
+++ b/scripts/course/courses/27.json
@@ -277,7 +277,7 @@
 	{
 		"chinese": "说",
 		"english": "to say",
-		"soundmark": "/tə/ /se/"
+		"soundmark": "/tə/ /seɪ/"
 	},
 	{
 		"chinese": "她（过去）说",

--- a/scripts/course/courses/27.json
+++ b/scripts/course/courses/27.json
@@ -167,7 +167,7 @@
 	{
 		"chinese": "正在钓鱼",
 		"english": "be fishing",
-		"soundmark": "/bi/ /'fɪʃɪŋ/ /（you，现在时）be are/ /ɚ/"
+		"soundmark": "/bi/ /'fɪʃɪŋ/"
 	},
 	{
 		"chinese": "你（现在）正在钓鱼",
@@ -277,7 +277,7 @@
 	{
 		"chinese": "说",
 		"english": "to say",
-		"soundmark": "/tə/ /se/ /（过去）说 said/ /sɛd/"
+		"soundmark": "/tə/ /se/"
 	},
 	{
 		"chinese": "她（过去）说",
@@ -472,7 +472,7 @@
 	{
 		"chinese": "告诉",
 		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/ /（过去）告诉 told/ /told/"
+		"soundmark": "/tə/ /tɛl/"
 	},
 	{
 		"chinese": "我（过去）告诉你",
@@ -532,7 +532,7 @@
 	{
 		"chinese": "承诺",
 		"english": "to promise",
-		"soundmark": "/tə/ /'prɑmɪs/ /（过去）承诺 promised/ /'prɑmɪst/"
+		"soundmark": "/tə/ /'prɑmɪs/"
 	},
 	{
 		"chinese": "你（过去）承诺",

--- a/scripts/course/courses/29.json
+++ b/scripts/course/courses/29.json
@@ -7,7 +7,7 @@
 	{
 		"chinese": "我",
 		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+		"soundmark": "/aɪ/"
 	},
 	{
 		"chinese": "我在这里",
@@ -132,7 +132,7 @@
 	{
 		"chinese": "我在这里",
 		"english": "I am here",
-		"soundmark": "/aɪ/ /æm/ /hɪr/ /(I，过去时)be was/ /wəz/"
+		"soundmark": "/aɪ/ /æm/ /hɪr/"
 	},
 	{
 		"chinese": "我(过去)在这里",
@@ -182,12 +182,12 @@
 	{
 		"chinese": "我注意到那个",
 		"english": "I notice that",
-		"soundmark": "/aɪ/ /ˈnotɪs/ /ðæt/ /(过去)注意到 noticed/ /ˈnotɪst/"
+		"soundmark": "/aɪ/ /ˈnotɪs/ /ðæt/"
 	},
 	{
 		"chinese": "我(过去)注意到那个",
 		"english": "I noticed that",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /(过去)没有 didn't/ /ˈdɪdnt/"
+		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/"
 	},
 	{
 		"chinese": "我(过去)没有注意到那个",
@@ -252,7 +252,7 @@
 	{
 		"chinese": "这里有错误的某个东西",
 		"english": "there is something wrong here",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
+		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
 	},
 	{
 		"chinese": "这里(过去)有错误的某个东西",
@@ -307,7 +307,7 @@
 	{
 		"chinese": "这里有不同的某个东西",
 		"english": "there is something different here",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
+		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
 	},
 	{
 		"chinese": "这里(过去)有不同的某个东西",

--- a/scripts/course/courses/30.json
+++ b/scripts/course/courses/30.json
@@ -587,21 +587,21 @@
 	{
 		"chinese": "说",
 		"english": "to say",
-		"soundmark": "/tə/ /se/"
+		"soundmark": "/tə/ /seɪ/"
 	},
 	{
 		"chinese": "你说",
 		"english": "you say",
-		"soundmark": "/ju/ /se/"
+		"soundmark": "/ju/ /seɪ/"
 	},
 	{
 		"chinese": "你说的内容",
 		"english": "what you say",
-		"soundmark": "/wɑt/ /ju/ /se/"
+		"soundmark": "/wɑt/ /ju/ /seɪ/"
 	},
 	{
 		"chinese": "你做的内容比你说的内容是更重要的",
 		"english": "what you do is more important than what you say",
-		"soundmark": "/wɑt/ /ju/ /du/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /wɑt/ /ju/ /se/"
+		"soundmark": "/wɑt/ /ju/ /du/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /wɑt/ /ju/ /seɪ/"
 	}
 ]

--- a/scripts/course/courses/30.json
+++ b/scripts/course/courses/30.json
@@ -357,12 +357,12 @@
 	{
 		"chinese": "你注意到",
 		"english": "you notice",
-		"soundmark": "/ju/ /ˈnotɪs/ /（过去）注意到 noticed/ /ˈnotɪst/"
+		"soundmark": "/ju/ /ˈnotɪs/"
 	},
 	{
 		"chinese": "你（过去）注意到",
 		"english": "you noticed",
-		"soundmark": "/ju/ /ˈnotɪst/ /（过去）没有 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /ˈnotɪst/"
 	},
 	{
 		"chinese": "你（过去）没有注意到",
@@ -487,7 +487,7 @@
 	{
 		"chinese": "没有东西比我们的友谊是更重要的",
 		"english": "nothing is more important than our friendship",
-		"soundmark": "/'nʌθɪŋ/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /'aʊɚ/ /ˈfrɛndʃɪp/ /A比B是更重要的 A is more important than B/ /e/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /bi/"
+		"soundmark": "/'nʌθɪŋ/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /'aʊɚ/ /ˈfrɛndʃɪp/"
 	},
 	{
 		"chinese": "家庭",
@@ -597,7 +597,7 @@
 	{
 		"chinese": "你说的内容",
 		"english": "what you say",
-		"soundmark": "/wɑt/ /ju/ /se/ /A比B是更重要的 A is more important than B/ /e/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /bi/"
+		"soundmark": "/wɑt/ /ju/ /se/"
 	},
 	{
 		"chinese": "你做的内容比你说的内容是更重要的",

--- a/scripts/course/courses/32.json
+++ b/scripts/course/courses/32.json
@@ -92,7 +92,7 @@
 	{
 		"chinese": "迈克尔杰克逊是在世界上最有名的歌手",
 		"english": "Michael Jackson is the most famous singer in the world",
-		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/ /ɪz/ /ðə/ /most/ /'feməs/ /'sɪŋɚ/ /ɪn/ /ðə/ /wɝld/ /（过去）是 was/ /wəz/"
+		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/ /ɪz/ /ðə/ /most/ /'feməs/ /'sɪŋɚ/ /ɪn/ /ðə/ /wɝld/"
 	},
 	{
 		"chinese": "迈克尔杰克逊（过去）是在世界上最有名的歌手",
@@ -162,7 +162,7 @@
 	{
 		"chinese": "蒙娜丽莎是最有名的画",
 		"english": "The Mona Lisa is the most famous painting",
-		"soundmark": "/ðə/ /'monə/ /ˈlisə/ /ɪz/ /ðə/ /most/ /'feməs/ /famous painting/ /'pentɪŋ/"
+		"soundmark": "/ðə/ /'monə/ /ˈlisə/ /ɪz/ /ðə/ /most/ /'feməs/ /'pentɪŋ/"
 	},
 	{
 		"chinese": "在世界上",
@@ -187,7 +187,7 @@
 	{
 		"chinese": "最有名的画（复数）",
 		"english": "the most famous paintings",
-		"soundmark": "/ðə/ /most/ /'feməs/ /'pentɪŋz/ /......之一 one of/ /wʌn/ /əv/"
+		"soundmark": "/ðə/ /most/ /'feməs/ /'pentɪŋz/"
 	},
 	{
 		"chinese": "最有名的画（复数）之一",
@@ -327,7 +327,7 @@
 	{
 		"chinese": "地标（复数）",
 		"english": "landmarks",
-		"soundmark": "/ˈlændmɑrks/ /......之一 one of/ /wʌn/ /əv/"
+		"soundmark": "/ˈlændmɑrks/"
 	},
 	{
 		"chinese": "最有名的地标之一",
@@ -347,7 +347,7 @@
 	{
 		"chinese": "更好的",
 		"english": "better",
-		"soundmark": "/ˈbɛtɚ/ /A是更好的 A is better/ /e/ /ɪz/ /ˈbɛtɚ/ /A比B是更好的 A is better than B/ /e/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /bi/"
+		"soundmark": "/ˈbɛtɚ/"
 	},
 	{
 		"chinese": "中文",
@@ -377,7 +377,7 @@
 	{
 		"chinese": "我的英文",
 		"english": "my English",
-		"soundmark": "/maɪ/ /ˈɪŋɡlɪʃ/ /A比B是更好的 A is better than B/ /e/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /bi/"
+		"soundmark": "/maɪ/ /ˈɪŋɡlɪʃ/"
 	},
 	{
 		"chinese": "你的中文比我的英文是更好的",
@@ -412,7 +412,7 @@
 	{
 		"chinese": "完成比完美是更好的",
 		"english": "done is better than perfect",
-		"soundmark": "/dʌn/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'pɝfɪkt/ /A比B是更好的 A is better than B/ /e/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /bi/"
+		"soundmark": "/dʌn/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'pɝfɪkt/"
 	},
 	{
 		"chinese": "夏天",
@@ -447,7 +447,7 @@
 	{
 		"chinese": "没有东西",
 		"english": "nothing",
-		"soundmark": "/'nʌθɪŋ/ /A比B是更好的 A is better than B/ /'sʌmθɪŋ/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'nʌθɪŋ/"
+		"soundmark": "/'nʌθɪŋ/"
 	},
 	{
 		"chinese": "某个东西比没有东西是更好的",
@@ -557,7 +557,7 @@
 	{
 		"chinese": "我最好的朋友们",
 		"english": "my best friends",
-		"soundmark": "/maɪ/ /bɛst/ /frendz/ /......之一 one of/ /wʌn/ /əv/"
+		"soundmark": "/maɪ/ /bɛst/ /frendz/"
 	},
 	{
 		"chinese": "我最好的朋友们之一",
@@ -592,7 +592,7 @@
 	{
 		"chinese": "我尽我的最大努力",
 		"english": "I do my best",
-		"soundmark": "/aɪ/ /du/ /maɪ/ /bɛst/ /（过去）做 did/ /dɪd/"
+		"soundmark": "/aɪ/ /du/ /maɪ/ /bɛst/"
 	},
 	{
 		"chinese": "我（过去）尽我最大努力",

--- a/scripts/course/courses/33.json
+++ b/scripts/course/courses/33.json
@@ -32,7 +32,7 @@
 	{
 		"chinese": "我想要打篮球",
 		"english": "I want to play basketball",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ple/ /'bæskɪtbɔl/ /(过去)想要 wanted/ /wɑntɪd/"
+		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ple/ /'bæskɪtbɔl/"
 	},
 	{
 		"chinese": "我(过去)想要打篮球",
@@ -42,7 +42,7 @@
 	{
 		"chinese": "使用",
 		"english": "to use",
-		"soundmark": "/tə/ /juz/ /(过去)使用 used/ /juzd/"
+		"soundmark": "/tə/ /juz/"
 	},
 	{
 		"chinese": "我(过去)想要打篮球",

--- a/scripts/course/courses/38.json
+++ b/scripts/course/courses/38.json
@@ -497,7 +497,7 @@
 	{
 		"chinese": "我是迟到的",
 		"english": "I am late",
-		"soundmark": "/aɪ/ /æm/ /let/ /(过去)避免 avoided/ /əˈvɔɪdɪd/"
+		"soundmark": "/aɪ/ /æm/ /let/"
 	},
 	{
 		"chinese": "是(ing形式)",

--- a/scripts/course/courses/41.json
+++ b/scripts/course/courses/41.json
@@ -27,7 +27,7 @@
 	{
 		"chinese": "决定",
 		"english": "to decide",
-		"soundmark": "/tə/ /dɪ'saɪd/ /(过去)决定 decided/ /dɪ'saɪdɪd/"
+		"soundmark": "/tə/ /dɪ'saɪd/"
 	},
 	{
 		"chinese": "她(过去)决定",
@@ -107,7 +107,7 @@
 	{
 		"chinese": "尝试",
 		"english": "to try",
-		"soundmark": "/tə/ /traɪ/ /(过去)尝试 tried/ /traɪd/"
+		"soundmark": "/tə/ /traɪ/"
 	},
 	{
 		"chinese": "她(过去)尝试",
@@ -382,7 +382,7 @@
 	{
 		"chinese": "决定",
 		"english": "to decide",
-		"soundmark": "/tə/ /dɪ'saɪd/ /(过去)决定 decided/ /dɪ'saɪdɪd/"
+		"soundmark": "/tə/ /dɪ'saɪd/"
 	},
 	{
 		"chinese": "她(过去)决定",

--- a/scripts/course/courses/42.json
+++ b/scripts/course/courses/42.json
@@ -187,7 +187,7 @@
 	{
 		"chinese": "你没有做这件事",
 		"english": "you don't do it",
-		"soundmark": "/ju/ /dont/ /du/ /ɪt/ /(过去)没有 didn't/ /ˈdɪdnt/"
+		"soundmark": "/ju/ /dont/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)没有做这件事",

--- a/scripts/course/courses/43.json
+++ b/scripts/course/courses/43.json
@@ -52,7 +52,7 @@
 	{
 		"chinese": "我的车被清洗了",
 		"english": "my car is washed",
-		"soundmark": "/maɪ/ /kɑr/ /ɪz/ /wɑʃt/ /(已经)洗完了 have washed/ /hæv/ /wɑʃt/"
+		"soundmark": "/maɪ/ /kɑr/ /ɪz/ /wɑʃt/"
 	},
 	{
 		"chinese": "我(已经)洗完了我的车",
@@ -142,7 +142,7 @@
 	{
 		"chinese": "去(ed形式)",
 		"english": "gone",
-		"soundmark": "/ɡɔn/ /(已经)去了 have gone/ /hæv/ /ɡɔn/"
+		"soundmark": "/ɡɔn/"
 	},
 	{
 		"chinese": "他们(已经)去了",
@@ -162,7 +162,7 @@
 	{
 		"chinese": "读(ed形式)",
 		"english": "read",
-		"soundmark": "/rɛd/ /(已经)读过 have read/ /hæv/ /rɛd/"
+		"soundmark": "/rɛd/"
 	},
 	{
 		"chinese": "我(已经)读过",
@@ -207,7 +207,7 @@
 	{
 		"chinese": "学到(ed形式)",
 		"english": "learned",
-		"soundmark": "/lɝnd/ /(已经)学到了 have learned/ /hæv/ /lɝnd/"
+		"soundmark": "/lɝnd/"
 	},
 	{
 		"chinese": "我(已经)学到了",
@@ -262,7 +262,7 @@
 	{
 		"chinese": "提高(ed形式)",
 		"english": "improved",
-		"soundmark": "/ɪmˈpruvd/ /(已经)提高了 have improved/ /hæv/ /ɪmˈpruvd/"
+		"soundmark": "/ɪmˈpruvd/"
 	},
 	{
 		"chinese": "你(已经)提高了",
@@ -307,7 +307,7 @@
 	{
 		"chinese": "参观(ed形式)",
 		"english": "visited",
-		"soundmark": "/'vɪzɪtɪd/ /(已经)参观过 have visited/ /hæv/ /'vɪzɪtɪd/"
+		"soundmark": "/'vɪzɪtɪd/"
 	},
 	{
 		"chinese": "我(已经)参观过",
@@ -402,7 +402,7 @@
 	{
 		"chinese": "教(ed形式)",
 		"english": "taught",
-		"soundmark": "/tɔt/ /(已经)教 have taught/ /hæv/ /tɔt/"
+		"soundmark": "/tɔt/"
 	},
 	{
 		"chinese": "我(已经)教了",

--- a/scripts/course/courses/43.json
+++ b/scripts/course/courses/43.json
@@ -162,12 +162,12 @@
 	{
 		"chinese": "读(ed形式)",
 		"english": "read",
-		"soundmark": "/rɛd/"
+		"soundmark": "/rid/"
 	},
 	{
 		"chinese": "我(已经)读过",
 		"english": "I have read",
-		"soundmark": "/aɪ/ /hæv/ /rɛd/"
+		"soundmark": "/aɪ/ /hæv/ /rid/"
 	},
 	{
 		"chinese": "那本书",
@@ -177,7 +177,7 @@
 	{
 		"chinese": "我(已经)读过那本书",
 		"english": "I have read that book",
-		"soundmark": "/aɪ/ /hæv/ /rɛd/ /ðæt/ /bʊk/"
+		"soundmark": "/aɪ/ /hæv/ /rid/ /ðæt/ /bʊk/"
 	},
 	{
 		"chinese": "次",
@@ -197,7 +197,7 @@
 	{
 		"chinese": "我(已经)读过那本书两次了",
 		"english": "I have read that book twice",
-		"soundmark": "/aɪ/ /hæv/ /rɛd/ /ðæt/ /bʊk/ /twaɪs/"
+		"soundmark": "/aɪ/ /hæv/ /rid/ /ðæt/ /bʊk/ /twaɪs/"
 	},
 	{
 		"chinese": "学到",

--- a/scripts/course/courses/45.json
+++ b/scripts/course/courses/45.json
@@ -82,7 +82,7 @@
 	{
 		"chinese": "他(已经)是一名医生了",
 		"english": "he has been a doctor",
-		"soundmark": "/hi/ /hæz/ /bɪn/ /ə/ /'dɑktɚ/ /fifteen/"
+		"soundmark": "/hi/ /hæz/ /bɪn/ /ə/ /'dɑktɚ/"
 	},
 	{
 		"chinese": "他(已经)是一名医生15年了",


### PR DESCRIPTION
通过正则检测匹配，删除课程音标中包含的中文以及多余的音标