### PR TITLE
fix: a11y bugs in home page

### DIFF
--- a/apps/client/components/main/MessageBox.vue
+++ b/apps/client/components/main/MessageBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog class="modal" :open="isShow">
+  <dialog class="modal invisible" :open="isShow">
     <div ref="dialogBoxRef" class="modal-box">
       <h3 class="font-bold text-lg">{{ title }}</h3>
       <p class="py-4">{{ content }}</p>

--- a/apps/client/pages/index.vue
+++ b/apps/client/pages/index.vue
@@ -14,11 +14,9 @@
               <i class="animate-wink inline w-1 h-8 dark:bg-white bg-slate-900 mx-2 text-2xl p-[2px]"></i>
             </div>
           </div>
-          <a class="mr-4" target="_blank" href="https://github.com/cuixueshe/earthworm">
-            <button class="btn w-48 indicator">
+          <a class="mr-4 btn w-48 indicator" target="_blank" href="https://github.com/cuixueshe/earthworm">
               <span class="indicator-item">🌟</span>
               Star us on GitHub
-            </button>
           </a>
           <button @click="handleKeydown"
             class="btn btn-outline w-48 hover:text-fuchsia-400 hover:border-fuchsia-400 hover:bg-fuchsia-100 text-fuchsia-300 border-fuchsia-300">


### PR DESCRIPTION
As a keyboard user i noticed 2 problems in the home page:

1) After focusing on theme toggle button, if user presses tab (to focus to next element) the focus indicator disappears, leaving user not knowing where the focus is.

<img width="1701" alt="Screenshot 2024-03-10 at 17 37 23" src="https://github.com/cuixueshe/earthworm/assets/72617743/6d5d3865-a947-4978-86d2-1b4c59c67ba6">
<img width="1703" alt="Screenshot 2024-03-10 at 17 39 01" src="https://github.com/cuixueshe/earthworm/assets/72617743/0919a875-7046-41bf-b258-2a2cdc2d5cc5">

I added a style so the modal (where focus is moved to) is hidden from accessibility tree, and focus navigation works as expected, moving to button.

2) The button "Star us on Github" also has an issue, because it has a button inside anchor tag (which hurts a11y), one visual element now takes 2 focuses (one for anchor, and one for button), and one focus (button focus) doesn't do anything.
<img width="1700" alt="Screenshot 2024-03-10 at 17 41 43" src="https://github.com/cuixueshe/earthworm/assets/72617743/f91a59ef-5c6c-4e9a-9aa1-eabf549f859c">
<img width="1705" alt="Screenshot 2024-03-10 at 17 41 55" src="https://github.com/cuixueshe/earthworm/assets/72617743/c03a8061-5111-4f64-8a2b-5a3a0c97bf45">

I removed button and merged its styles to anchor.