### PR TITLE
feat: implement scroll to active course card on mount

### DIFF
--- a/apps/client/composables/courses/scroll.ts
+++ b/apps/client/composables/courses/scroll.ts
@@ -1,0 +1,10 @@
+export function useCourseScrollIntoView(){
+ 
+  function scrollIntoView(el: HTMLElement) {
+    el && el.scrollIntoView()
+  }
+
+  return {
+    scrollIntoView
+  }
+}

--- a/apps/client/pages/Courses.vue
+++ b/apps/client/pages/Courses.vue
@@ -10,6 +10,7 @@
           <NuxtLink
             :href="`/main/${course.id}`"
             @click="handleChangeCourse(course)"
+            :course-id="course.id"
           >
             <CourseCard
               :title="course.title"
@@ -29,9 +30,12 @@ import { type Course } from "~/store/course";
 import { fetchCourses } from "~/api/course";
 import Loading from "~/components/Loading.vue";
 import CourseCard from "~/components/courses/CourseCard.vue";
-import { ref, onMounted } from "vue";
+import { ref, onMounted, nextTick } from "vue";
 import { fetchCourseHistory } from "~/api/courseHistory";
 import { useActiveCourseId } from "~/composables/courses/activeCourse";
+import { useCourseScrollIntoView } from "~/composables/courses/scroll"
+
+const { scrollIntoView } = useCourseScrollIntoView()
 
 const courses = ref<Course[]>([]);
 
@@ -63,9 +67,11 @@ async function getCourses() {
 
 onMounted(async () => {
   courses.value = await getCourses();
+  await nextTick();
+  scrollIntoView(document.querySelector(`[course-id="${activeCourseId.value}"]`)!);
 });
 
-const { updateActiveCourseId } = useActiveCourseId();
+const { updateActiveCourseId, activeCourseId } = useActiveCourseId();
 function handleChangeCourse(course: Course) {
   updateActiveCourseId(course.id);
 }


### PR DESCRIPTION
#253 

实现思路
通过给 course card 添加 course-id 属性来找当前的 dom，然后调用 scrollIntoView()

<img width="1258" alt="image" src="https://github.com/cuixueshe/earthworm/assets/9922823/a0f8110d-8110-47dd-9930-c5a72726bea7">
