### PR TITLE
fix: 避免光标元素右边距导致无必要的横向滚动条

### DIFF
--- a/apps/client/pages/index.vue
+++ b/apps/client/pages/index.vue
@@ -162,7 +162,7 @@
                   切换到设置页面，自定义你喜欢的快捷键，也可以控制语音是否自动播放、单词下划线固定长度、使用空格提交等等……更多个人设置会持续更新
                   😊
                   <i
-                    class="animate-wink inline w-1 h-8 dark:bg-white bg-slate-900 mx-2 text-sm p-[2px]"
+                    class="animate-wink inline w-1 h-8 dark:bg-white bg-slate-900 ml-2 text-sm p-[2px]"
                   ></i>
                 </p>
               </div>


### PR DESCRIPTION
如图所示：
![image](https://github.com/cuixueshe/earthworm/assets/13738577/c0ff51f4-2afb-4eb4-b2cb-a5490a15fc41)
