### PR TITLE
refactor: resolve compiling warnings in the client directory

### DIFF
--- a/apps/client/components/main/Message/message.vue
+++ b/apps/client/components/main/Message/message.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup name="Message">
 import { onMounted, ref } from "vue";
-import { Type } from './Message.ts';
+import { Type } from "./Message";
 
 const { type = Type.SUCCESS, duration = 2000 } = defineProps<{
   type?: Type;

--- a/apps/client/components/main/StudyVideoLink.vue
+++ b/apps/client/components/main/StudyVideoLink.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps, withDefaults } from "vue";
+import { computed, withDefaults } from "vue";
 import { getCourseLink } from "~/utils/courseLinks";
 
 const NOTE_TIP = "边学边练：点击跳转至星荣英语笔记";

--- a/apps/client/pages/Auth/FormInput.vue
+++ b/apps/client/pages/Auth/FormInput.vue
@@ -23,8 +23,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineEmits, defineProps } from "vue";
-
 const props = defineProps({
   label: String,
   name: String,


### PR DESCRIPTION
解决 client 下编译 warn 警告提示

![b01c260a9ae31062b157c6f2fdc21d0](https://github.com/cuixueshe/earthworm/assets/45628596/4928bfcf-bbcb-419a-ab64-4fa54287b407)

主要是 2 个警告
1. Vue 的单文件组件编译器（@vue/compiler-sfc）引起的warn。提示不再需要显式导入 defineEmits 和 defineProps，因为它已经成为编译器的宏。这个变化是在 Vue 3.2.0 版本中引入的，目前项目中 Vue 版本 ^3.4.6。
2. Message 和 MessageBox 组件名称相同冲突，具有相同的名称但位于不同的文件路径中

针对第 1 个告警，移除defineEmits 和 defineProps 的显式导入
第 2 个告警，可以
- 重命名其中一个组件：更改其中一个组件的文件名或组件名称，以确保它们不再具有相同的名称。
- 移动其中一个组件：将其中一个组件文件移动到其他目录，以确保每个组件都有唯一的路径和名称。

但这需要讨论一下
