### PR TITLE
fix(Game.vue): error padding on 4k screen

### DIFF
--- a/apps/client/components/main/Game.vue
+++ b/apps/client/components/main/Game.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full pt-20">
+  <div class="h-full pt-20 lg:pt-5">
     <div class="h-[40vh] flex flex-col justify-center">
       <template v-if="isQuestion()">
         <Question></Question>


### PR DESCRIPTION
before: 
<img width="1918" alt="1" src="https://github.com/cuixueshe/earthworm/assets/20318651/6d076f02-da8c-4e8a-b53f-087cd9b8288d">
after:
<img width="1918" alt="2" src="https://github.com/cuixueshe/earthworm/assets/20318651/c8d65f65-cc83-4527-b421-c34262fdcbcd">
