### PR TITLE
fix: verify whether shortcut keys are duplicated

### DIFF
--- a/apps/client/components/user/Setting.vue
+++ b/apps/client/components/user/Setting.vue
@@ -125,6 +125,9 @@
       <div class="text-center mt-2 text-xs">
         {{ shortcutKeyTip }}
       </div>
+      <div v-if="hasSameShortcutKey" class="text-center mt-4 text-xs" :class="'text-[rgba(136,136,136,1)]'" >
+        已有相同的按键绑定，请重新设置
+      </div>
     </div>
   </dialog>
 </template>
@@ -156,6 +159,7 @@ const {
   shortcutKeys,
   shortcutKeyStr,
   shortcutKeyTip,
+  hasSameShortcutKey,
   handleEdit,
   handleCloseDialog,
   handleKeydown,

--- a/apps/client/composables/user/shortcutKey.ts
+++ b/apps/client/composables/user/shortcutKey.ts
@@ -48,8 +48,7 @@ export function useShortcutKeyMode() {
   const shortcutKeyTip = computed(() => {
     return shortcutKeyStr.value.replace(/\+/g, " 加上 ");
   });
-  const hasSameShortcutKey  = ref(false)
-
+  const hasSameShortcutKey = ref(false);
 
   // 初始化快捷键
   setShortcutKeys();
@@ -71,7 +70,7 @@ export function useShortcutKeyMode() {
 
   function handleCloseDialog() {
     showModal.value = false;
-    hasSameShortcutKey.value = false
+    hasSameShortcutKey.value = false;
   }
 
   function getKeyModifier(e: KeyboardEvent) {
@@ -93,11 +92,11 @@ export function useShortcutKeyMode() {
   function isEnterKey(key: string) {
     return key === KEYBOARD.ENTER;
   }
-  function checkShortcutKey(key: string) {
+
+  function checkSameShortcutKey(key: string) {
     const keys = Object.values(shortcutKeys.value);
-    const hasSameKey = keys.some(x => x === key && x !== shortcutKeys.value[currentKeyType.value]);
-    hasSameShortcutKey.value = hasSameKey;
-    return hasSameKey;
+    const currentShortcutKey = shortcutKeys.value[currentKeyType.value];
+    return keys.some((x) => x === key && x !== currentShortcutKey);
   }
   /**
    * 参考于 VSCode 快捷键
@@ -111,7 +110,9 @@ export function useShortcutKeyMode() {
     e.preventDefault();
     const mainKey = getKeyModifier(e);
     if (!mainKey && isEnterKey(e.key)) {
-      if(!checkShortcutKey(shortcutKeyStr.value)){
+      if (checkSameShortcutKey(shortcutKeyStr.value)) {
+        hasSameShortcutKey.value = true;
+      } else {
         saveShortcutKeys();
         handleCloseDialog();
       }

--- a/apps/client/composables/user/shortcutKey.ts
+++ b/apps/client/composables/user/shortcutKey.ts
@@ -48,6 +48,8 @@ export function useShortcutKeyMode() {
   const shortcutKeyTip = computed(() => {
     return shortcutKeyStr.value.replace(/\+/g, " 加上 ");
   });
+  const hasSameShortcutKey  = ref(false)
+
 
   // 初始化快捷键
   setShortcutKeys();
@@ -69,6 +71,7 @@ export function useShortcutKeyMode() {
 
   function handleCloseDialog() {
     showModal.value = false;
+    hasSameShortcutKey.value = false
   }
 
   function getKeyModifier(e: KeyboardEvent) {
@@ -90,7 +93,12 @@ export function useShortcutKeyMode() {
   function isEnterKey(key: string) {
     return key === KEYBOARD.ENTER;
   }
-
+  function checkShortcutKey(key: string) {
+    const keys = Object.values(shortcutKeys.value);
+    const hasSameKey = keys.some(x => x === key && x !== shortcutKeys.value[currentKeyType.value]);
+    hasSameShortcutKey.value = hasSameKey;
+    return hasSameKey;
+  }
   /**
    * 参考于 VSCode 快捷键
    * 有待讨论，产品角度出发，快捷键应该只支持组合键形式
@@ -103,13 +111,14 @@ export function useShortcutKeyMode() {
     e.preventDefault();
     const mainKey = getKeyModifier(e);
     if (!mainKey && isEnterKey(e.key)) {
-      saveShortcutKeys();
-      handleCloseDialog();
+      if(!checkShortcutKey(shortcutKeyStr.value)){
+        saveShortcutKeys();
+        handleCloseDialog();
+      }
       return;
     }
 
     const key = convertMacKey(e.key);
-    // TODO: 需要校验当前快捷键是否与其他快捷键重复，重复则不允许设置
     if (SPECIAL_KEYS.has(e.key) || !mainKey) {
       // 单键
       shortcutKeyStr.value = key;
@@ -124,6 +133,7 @@ export function useShortcutKeyMode() {
     shortcutKeys, // 快捷键对象
     shortcutKeyStr, // 单个修改的快捷键
     shortcutKeyTip, // 快捷键输入框底部注释
+    hasSameShortcutKey, // 是否有相同的快捷键
     setShortcutKeys,
     handleKeydown,
     handleEdit,

--- a/apps/client/composables/user/tests/shortcutKey.spec.ts
+++ b/apps/client/composables/user/tests/shortcutKey.spec.ts
@@ -144,5 +144,64 @@ describe("user defined shortcut key", () => {
       expect(showModal.value).toBeFalsy();
       expect(shortcutKeys.value).toMatchObject({ [answerKey]: "Ctrl+s" });
     });
+    it("should be not set successfully with the same shortcut", () => {
+      const { showModal, shortcutKeys, handleEdit, handleKeydown, hasSameShortcutKey } =
+        useShortcutKeyMode();
+
+      handleEdit(answerKey);
+
+      expect(showModal.value).toBeTruthy();
+
+      handleKeydown({
+        key: "s",
+        metaKey: true,
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      handleKeydown({
+        key: "Enter",
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      expect(hasSameShortcutKey.value).toBeFalsy()
+      expect(showModal.value).toBeFalsy();
+      expect(shortcutKeys.value).toMatchObject({ [answerKey]: "Command+s" });
+
+      handleEdit(soundKey);
+
+      expect(showModal.value).toBeTruthy();
+
+      handleKeydown({
+        key: "s",
+        metaKey: true,
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      handleKeydown({
+        key: "Enter",
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      
+      expect(hasSameShortcutKey.value).toBeTruthy()
+      expect(showModal.value).toBeTruthy();
+      expect(shortcutKeys.value).toMatchObject({ [answerKey]: "Command+s", [soundKey]: "Ctrl+'" });
+    })
+    it("should be the shortcut key is set successfully with the same key", () => {
+      const { showModal, shortcutKeys, handleEdit, handleKeydown, hasSameShortcutKey } =
+      useShortcutKeyMode();
+
+      handleEdit(answerKey);
+
+      expect(showModal.value).toBeTruthy();
+      handleKeydown({
+        key: ";",
+        ctrlKey: true,
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      handleKeydown({
+        key: "Enter",
+        preventDefault: () => {},
+      } as KeyboardEvent);
+      expect(hasSameShortcutKey.value).toBeFalsy()
+      expect(showModal.value).toBeFalsy();
+      expect(shortcutKeys.value).toMatchObject({ [answerKey]: "Ctrl+;" });
+    })
   });
 });


### PR DESCRIPTION
编辑快捷键时，校验是否已有快捷键重复

<img width="1060" alt="1" src="https://github.com/cuixueshe/earthworm/assets/52577448/5e2b90e6-113e-4dc4-a8e1-5c7cd5f083ee">
