### PR TITLE
fix: cypress running locally

### DIFF
--- a/apps/client/cypress.config.ts
+++ b/apps/client/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl:"http://localhost:3000/",
+    baseUrl: "http://127.0.0.1:3000/",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/apps/client/nuxt.config.ts
+++ b/apps/client/nuxt.config.ts
@@ -17,6 +17,9 @@ function addClarity() {
 }
 
 export default defineNuxtConfig({
+  devServer: {
+    host: "0.0.0.0",
+  },
   css: ["~/assets/css/globals.css"],
   ssr: false,
   devtools: { enabled: true },


### PR DESCRIPTION
因为最近不少小伙伴问我前端本地 e2e 好像跑不起来或者是一直报错，所以我就去看了看，然后发现……我自己也跑不起来 😭

所以就花点时间看看，先下结论：通过方案一 + 方案三至少我本地是可行的，但不确定其他小伙伴是否可行，还是没有完美的解决和找到问题所在，为什么前端可以正常访问 localhost:3000 而在 e2e 工具中就不行了，难不成做劫持了？🤔

大家可以先试试这个方案~ 后面让崔哥找找问题哈哈

[Cypress 仓库](https://github.com/cypress-io/cypress) 查看了下目前最新版本是 13.7.1，是上周更新的，但我检索了项目 pnpm-lock 版本中是 13.6.4，两个月前的，那就是锁了版本的，按理来说应该不是更新上导致的问题

类似的 issue [cy.visit() failed trying to load ESOCKETTIMEDOUT · Issue #7062 · cypress-io/cypress · GitHub](https://github.com/cypress-io/cypress/issues/7062)

- 方案一：将 `nuxt.config.ts` 文件中 devServer 下的 host 参数设置 0.0.0.0
	- 关闭 proxy 代理 ✅
	- 关闭 obsidian（防止端口服务占用冲突）✅
	- 前端服务是正常启动的，端口为 3000，可以通过浏览器 localhost/127.0.0.1/局域网 IP 进行访问 ✅
	- 通过 `cypress open` 打开的工具中可以正常连接和运行测试 ✅
	- 但启动页面上有警告信息，提示不能连接到 baseUrl（设置连接的 url）❌
	- 通过 `cypress run` 终端方式，直接报错，无法连接 ❌

![image](https://github.com/cuixueshe/earthworm/assets/48991003/ecd239c9-ac7c-4ff6-81d4-9c5215654586)

![image](https://github.com/cuixueshe/earthworm/assets/48991003/f6dd89b0-4127-439a-ae3b-e3c4cf2b8efe)

- 方案二：升级到 13.7.1 目前的最新版本试试
	- 与升级前出现的行为一致，无法解决问题

- 方案三：在方案一的基础上将 cypress.config.ts 中设置的 baseUrl 修改为 127.0.0.1
	- obsidian + proxy + 前端服务正常启动 ✅
	- 通过 `cypress open` 工具启动，可成功连接与操作 ✅
	- 通过 `cypress run` 终端启动，测试通过 ✅

![image](https://github.com/cuixueshe/earthworm/assets/48991003/50760545-1eed-4425-9b1f-cca64ab36b56)

![image](https://github.com/cuixueshe/earthworm/assets/48991003/16bbbf96-6231-4b7f-ba10-6954b5b99964)
