### PR TITLE
feat: add skip shortcut key

### DIFF
--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -19,6 +19,16 @@
       <span class="ml-2">{{ toggleTipText }}</span>
     </div>
 
+    <div class="w-[210px] mb-4">
+      <button
+        class="tip-btn"
+        @click="goToNextQuestion"
+      >
+      ⌃ {{ shortcutKeys.skip }}
+      </button>
+      <span class="ml-2">skip</span>
+    </div>
+
     <div class="w-[210px]">
       <button
         class="tip-btn"
@@ -36,6 +46,7 @@ import { computed, onMounted, onUnmounted } from "vue";
 import { useAnswerTip } from "~/composables/main/answerTip";
 import { useCurrentStatementEnglishSound } from "~/composables/main/englishSound";
 import { useGameMode } from "~/composables/main/game";
+import { useGoToNextQuestion } from "~/composables/main/goToNextQuestion";
 import { useSummary } from "~/composables/main/summary";
 import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
@@ -43,6 +54,7 @@ import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
 const { shortcutKeys } = useShortcutKeyMode();
 const { playSound } = usePlaySound(shortcutKeys.value.sound);
 const { toggleGameMode } = useShowAnswer(shortcutKeys.value.answer);
+const { goToNextQuestion } = useSkip(shortcutKeys.value.skip)
 
 const toggleTipText = computed(() => {
   let text = "";
@@ -122,6 +134,26 @@ function useShowAnswer(key: string) {
   return {
     toggleGameMode,
   };
+}
+
+function useSkip(key: string){
+  const {goToNextQuestion}=useGoToNextQuestion()
+  onMounted(() => {
+    registerShortcut(key, skipCommand);
+  });
+
+  onUnmounted(() => {
+    cancelShortcut(key, skipCommand);
+  });
+
+  function skipCommand(e: KeyboardEvent) {
+    e.preventDefault();
+    goToNextQuestion();
+  }
+
+  return {
+    goToNextQuestion
+  }
 }
 </script>
 

--- a/apps/client/components/user/Setting.vue
+++ b/apps/client/components/user/Setting.vue
@@ -35,6 +35,18 @@
               </button>
             </td>
           </tr>
+          <tr class="hover">
+            <td class="label-text">跳过</td>
+            <td class="text-center">{{ shortcutKeys.skip }}</td>
+            <td class="text-center">
+              <button
+                class="btn btn-sm btn-outline btn-secondary"
+                @click="handleEdit('skip')"
+              >
+                编辑
+              </button>
+            </td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -151,13 +163,13 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from "vue";
 import {
-  PronunciationType,
-  usePronunciation,
+PronunciationType,
+usePronunciation,
 } from "~/composables/user/pronunciation";
 import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
 import {
-  useAutoPronunciation,
-  useKeyboardSound,
+useAutoPronunciation,
+useKeyboardSound,
 } from "~/composables/user/sound";
 import { useSpaceSubmitAnswer } from "~/composables/user/submitKey";
 import { useShowWordsWidth } from "~/composables/user/words";

--- a/apps/client/composables/main/goToNextQuestion.ts
+++ b/apps/client/composables/main/goToNextQuestion.ts
@@ -1,0 +1,23 @@
+import { useGameMode } from "~/composables/main/game";
+import { useSummary } from "~/composables/main/summary";
+import { useCourseStore } from "~/store/course";
+const { showSummary } = useSummary();
+const { showQuestion } = useGameMode();
+
+const courseStore = useCourseStore();
+
+export function useGoToNextQuestion() {
+  function goToNextQuestion() {
+    if (courseStore.isAllDone()) {
+      showSummary();
+      return;
+    }
+
+    courseStore.toNextStatement();
+    showQuestion();
+  }
+
+  return {
+    goToNextQuestion,
+  };
+}

--- a/apps/client/composables/user/shortcutKey.ts
+++ b/apps/client/composables/user/shortcutKey.ts
@@ -4,6 +4,7 @@ export const SHORTCUT_KEYS = "shortcutKeys";
 export const DEFAULT_SHORTCUT_KEYS = {
   sound: "Ctrl+'",
   answer: "Ctrl+;",
+  skip:"Ctrl+."
 };
 export const KEYBOARD = {
   ESC: "Esc",


### PR DESCRIPTION
#412 

- 新增跳过功能 默认快捷键 Ctrl + .
<img width="838" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/d0217bfc-8abe-43bd-b38c-d225d6445553">

- 设置页面添加跳过功能快捷键自定义
<img width="1185" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/baeaa2a2-3894-4cd0-b59d-78ec95ee99b9">
