### PR TITLE
fix: db upload error

### DIFF
--- a/packages/xingrong-courses/src/courses.ts
+++ b/packages/xingrong-courses/src/courses.ts
@@ -1,10 +1,11 @@
 import { db } from "@earthworm/db";
-import { course as courseSchema } from "@earthworm/schema";
+import { course as courseSchema, statement as statementSchema } from "@earthworm/schema";
 import fs from "fs";
 import path from "path";
 const courses = fs.readdirSync(path.resolve(__dirname, "../data/courses"));
 
 (async function () {
+  await db.delete(statementSchema)
   await db.delete(courseSchema);
 
   for (const [index, course] of courses.entries()) {


### PR DESCRIPTION
修复执行 `pnpm db:upload` 时报错

> Cannot delete or update a parent row: a foreign key constraint fails (`earthworm_nest`.`statements`, CONSTRAINT `statements_course_id_courses_id_fk` FOREIGN KEY (`course_id`) REFERENCES `courses` (`id`))

原因是 `courses` 表 与 `statements` 表之间存在外键约束，删除主表 `courses` 的同时还要删除外键表 `statements`