### PR TITLE
fix: chinese-semantic-optimization 

### DIFF
--- a/packages/xingrong-courses/data/courses/01.json
+++ b/packages/xingrong-courses/data/courses/01.json
@@ -600,17 +600,17 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某些事情",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我需要告诉你某些事情",
+		"chinese": "我需要告诉你一些事情",
 		"english": "I need to tell you something",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "我需要告诉你重要的某些事情",
+		"chinese": "我需要告诉你一些重要的事情",
 		"english": "I need to tell you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -620,7 +620,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -630,7 +630,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "It is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -645,12 +645,12 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是重要的",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是非常重要的",
+		"chinese": "这对我来说非常重要",
 		"english": "It is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -660,7 +660,7 @@
 		"soundmark": "/tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "做这件事情（它）是重要的",
+		"chinese": "做这件事情是重要的",
 		"english": "It is important to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /du/ /ɪt/"
 	},
@@ -670,7 +670,7 @@
 		"soundmark": "/tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里（它）是重要的",
+		"chinese": "来到这里是重要的",
 		"english": "It is important to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /bi/ /hɪr/"
 	},
@@ -680,7 +680,7 @@
 		"soundmark": "/tə/ /it/ /ðə/ /fud/"
 	},
 	{
-		"chinese": "吃这个食物（它）是重要的",
+		"chinese": "吃这个食物是重要的",
 		"english": "It is important to eat the food",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /it/ /ðə/ /fud/"
 	},
@@ -690,7 +690,7 @@
 		"soundmark": "/ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "它是不可能的",
+		"chinese": "这是不可能的",
 		"english": "It is impossible",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
@@ -700,12 +700,12 @@
 		"soundmark": "/tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "做这件事情（它）是不可能的",
+		"chinese": "这是不可能做到的",
 		"english": "It is impossible to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "现在做这件事情（它）是不可能的",
+		"chinese": "现在不可能做到",
 		"english": "It is impossible to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -715,7 +715,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是不可能的",
+		"chinese": "对我来说这是不可能的",
 		"english": "It is impossible for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /fɝ/ /mi/"
 	},
@@ -735,12 +735,12 @@
 		"soundmark": "/tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里（它）是好的",
+		"chinese": "来到这里真好",
 		"english": "It is good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里（它）是非常好的",
+		"chinese": "来到这里非常好",
 		"english": "It is very good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
@@ -750,7 +750,7 @@
 		"soundmark": "/tə/ /si/ /ju/"
 	},
 	{
-		"chinese": "见到你（它）是非常好的",
+		"chinese": "很高兴见到你",
 		"english": "It is very good to see you",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /si/ /ju/"
 	},
@@ -760,7 +760,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "每天见到你（它）是非常好的",
+		"chinese": "每天都能见到你真是太好了",
 		"english": "It is very good to see you every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /si/ /ju/ /'ɛvri/ /de/"
 	},
@@ -770,7 +770,7 @@
 		"soundmark": "/'pɑsəbl/"
 	},
 	{
-		"chinese": "它是可能的",
+		"chinese": "这是有可能的",
 		"english": "It is possible",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/"
 	},
@@ -780,7 +780,7 @@
 		"soundmark": "/tə/ /si/ /ju/"
 	},
 	{
-		"chinese": "见到你（它）是可能的",
+		"chinese": "有可能见到你",
 		"english": "It is possible to see you",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/ /tə/ /si/ /ju/"
 	},
@@ -790,7 +790,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "每天见到你（它）是可能的",
+		"chinese": "有可能每天都能见到你",
 		"english": "It is possible to see you every day",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/ /tə/ /si/ /ju/ /'ɛvri/ /de/"
 	},
@@ -800,7 +800,7 @@
 		"soundmark": "/ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "每天见到你（它）是不可能的",
+		"chinese": "不可能每天都能见到你",
 		"english": "It is impossible to see you every day",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /tə/ /si/ /ju/ /'ɛvri/ /de/"
 	},
@@ -820,17 +820,17 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否它是可能的",
+		"chinese": "我想要知道这是否有可能",
 		"english": "I want to know if it is possible",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /'pɑsəbl/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要知道是否它是重要的",
+		"chinese": "我想要知道这是否重要",
 		"english": "I want to know if it is important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -840,7 +840,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是重要的",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -865,12 +865,12 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我必须做这件事",
+		"chinese": "这对我来说是重要的，所以我必须这么做",
 		"english": "It is important for me so I have to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我今天必须做这件事",
+		"chinese": "这对我来说是重要的，所以我必须今天就做",
 		"english": "It is important for me so I have to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -880,7 +880,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我必须每天做这件事",
+		"chinese": "这对我来说是重要的，所以我必须每天做",
 		"english": "It is important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -890,7 +890,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须每天做这件事",
+		"chinese": "这对我来说非常重要，所以我必须每天做",
 		"english": "It is very important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -900,7 +900,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须现在做这件事",
+		"chinese": "这对我来说非常重要，所以我必须现在就去做",
 		"english": "It is very important for me so I have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -910,12 +910,12 @@
 		"soundmark": "/nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "It is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的对我来说",
+		"chinese": "这对我来说并不重要",
 		"english": "It is not important for me",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -945,7 +945,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它不是重要的对我来说所以我不必现在做这件事情",
+		"chinese": "这对我来说并不重要，所以我现在不必做了",
 		"english": "It is not important for me so I don't have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /dont/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -960,7 +960,7 @@
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
 	{
-		"chinese": "我需要告诉你重要的某些事情",
+		"chinese": "我需要告诉你一些重要的事情",
 		"english": "I need to tell you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -970,17 +970,17 @@
 		"soundmark": "/aɪ/ /hæv/ /tə/ /no/ /ju/ /sun/"
 	},
 	{
-		"chinese": "来到这里（它）是好的",
+		"chinese": "来到这里真好",
 		"english": "It is good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "它是重要的对我来说",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "现在做这件事情（它）是不可能的",
+		"chinese": "现在不可能做到",
 		"english": "It is impossible to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /tə/ /du/ /ɪt/ /naʊ/"
 	},

--- a/packages/xingrong-courses/data/courses/01.json
+++ b/packages/xingrong-courses/data/courses/01.json
@@ -620,7 +620,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "这是重要的",
+		"chinese": "这很重要",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -630,7 +630,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这是非常重要的",
+		"chinese": "这非常重要",
 		"english": "It is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -645,7 +645,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "这对我来说是重要的",
+		"chinese": "这对我来说很重要",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -660,7 +660,7 @@
 		"soundmark": "/tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "做这件事情是重要的",
+		"chinese": "这样做很重要",
 		"english": "It is important to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /du/ /ɪt/"
 	},
@@ -670,7 +670,7 @@
 		"soundmark": "/tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里是重要的",
+		"chinese": "来这里很重要",
 		"english": "It is important to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /bi/ /hɪr/"
 	},
@@ -680,7 +680,7 @@
 		"soundmark": "/tə/ /it/ /ðə/ /fud/"
 	},
 	{
-		"chinese": "吃这个食物是重要的",
+		"chinese": "吃这个食物很重要",
 		"english": "It is important to eat the food",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /tə/ /it/ /ðə/ /fud/"
 	},
@@ -825,7 +825,7 @@
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /'pɑsəbl/"
 	},
 	{
-		"chinese": "这是重要的",
+		"chinese": "这很重要",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -865,12 +865,12 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "这对我来说是重要的，所以我必须这么做",
+		"chinese": "这对我来说很重要，所以我必须这么做",
 		"english": "It is important for me so I have to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "这对我来说是重要的，所以我必须今天就做",
+		"chinese": "这对我来说很重要，所以我必须今天就做",
 		"english": "It is important for me so I have to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -880,7 +880,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "这对我来说是重要的，所以我必须每天做",
+		"chinese": "这对我来说很重要，所以我必须每天都做",
 		"english": "It is important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -890,7 +890,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这对我来说非常重要，所以我必须每天做",
+		"chinese": "这对我来说非常重要，所以我必须每天都做",
 		"english": "It is very important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -900,7 +900,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "这对我来说非常重要，所以我必须现在就去做",
+		"chinese": "这对我来说非常重要，所以我必须现在就做",
 		"english": "It is very important for me so I have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},

--- a/packages/xingrong-courses/data/courses/02.json
+++ b/packages/xingrong-courses/data/courses/02.json
@@ -25,7 +25,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -65,7 +65,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否我是重要的",
+		"chinese": "我想要知道我是否重要",
 		"english": "I want to know if I am important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /ɪm'pɔrtnt/"
 	},
@@ -75,7 +75,7 @@
 		"soundmark": "/nid/ /tə/ /no/"
 	},
 	{
-		"chinese": "我需要知道是否我是重要的",
+		"chinese": "我需要知道我是否重要",
 		"english": "I need to know if I am important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /ɪm'pɔrtnt/"
 	},
@@ -90,7 +90,7 @@
 		"soundmark": "/aɪ/ /æm/ /'pɝfɪkt/"
 	},
 	{
-		"chinese": "我需要知道是否我是完美的",
+		"chinese": "我需要知道我是否完美",
 		"english": "I need to know if I am perfect",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /'pɝfɪkt/"
 	},
@@ -100,7 +100,7 @@
 		"soundmark": "/hæv/ /tə/ /no/"
 	},
 	{
-		"chinese": "我必须知道是否我是完美的",
+		"chinese": "我必须知道我是否完美",
 		"english": "I have to know if I am perfect",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /'pɝfɪkt/"
 	},
@@ -115,7 +115,7 @@
 		"soundmark": "/aɪ/ /æm/ /'hɛlθi/"
 	},
 	{
-		"chinese": "我必须知道是否我是健康的",
+		"chinese": "我必须知道我是否健康",
 		"english": "I have to know if I am healthy",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /'hɛlθi/"
 	},
@@ -220,7 +220,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否你是周杰伦",
+		"chinese": "我想要知道你是否是周杰伦",
 		"english": "I want to know if you are Jay Chou",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /ɚ/ /dʒe/ /tʃo/"
 	},
@@ -235,7 +235,7 @@
 		"soundmark": "/ju/ /ɚ/ /'hɛlθi/"
 	},
 	{
-		"chinese": "我需要知道是否你是健康的",
+		"chinese": "我需要知道你是否健康",
 		"english": "I need to know if you are healthy",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /ju/ /ɚ/ /'hɛlθi/"
 	},
@@ -250,7 +250,7 @@
 		"soundmark": "/ju/ /ɚ/ /'pɝfɪkt/"
 	},
 	{
-		"chinese": "我必须知道是否你是完美的",
+		"chinese": "我必须知道是你是否完美",
 		"english": "I have to know if you are perfect",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /no/ /ɪf/ /ju/ /ɚ/ /'pɝfɪkt/"
 	},
@@ -300,7 +300,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -440,12 +440,12 @@
 		"soundmark": "/wɪð/ /mi/"
 	},
 	{
-		"chinese": "和我说话",
+		"chinese": "和我聊聊",
 		"english": "to talk with me",
 		"soundmark": "/tə/ /tɔk/ /wɪð/ /mi/"
 	},
 	{
-		"chinese": "你想要和我说话",
+		"chinese": "你想要和我聊聊",
 		"english": "You want to talk with me",
 		"soundmark": "/ju/ /wɑnt/ /tə/ /tɔk/ /wɪð/ /mi/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "你想要现在和我说话",
+		"chinese": "你现在想要和我聊聊",
 		"english": "You want to talk with me now",
 		"soundmark": "/ju/ /wɑnt/ /tə/ /tɔk/ /wɪð/ /mi/ /naʊ/"
 	},
@@ -500,7 +500,7 @@
 		"soundmark": "/ju/ /hæv/ /tə/ /hɛlp/ /mi/"
 	},
 	{
-		"chinese": "你必须现在帮助我",
+		"chinese": "你现在必须帮助我",
 		"english": "You have to help me now",
 		"soundmark": "/ju/ /hæv/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -545,7 +545,7 @@
 		"soundmark": "/ju/ /nid/ /tə/ /it/ /ðə/ /fud/"
 	},
 	{
-		"chinese": "你需要现在吃这个食物",
+		"chinese": "你现在需要吃这个食物",
 		"english": "You need to eat the food now",
 		"soundmark": "/ju/ /nid/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -595,12 +595,12 @@
 		"soundmark": "/ju/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
 	},
 	{
-		"chinese": "和我说话",
+		"chinese": "与我聊聊",
 		"english": "to talk with me",
 		"soundmark": "/tə/ /tɔk/ /wɪð/ /mi/"
 	},
 	{
-		"chinese": "你喜欢和我说话",
+		"chinese": "你喜欢和我聊天",
 		"english": "You like to talk with me",
 		"soundmark": "/ju/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
 	},
@@ -610,7 +610,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "你喜欢每天和我说话",
+		"chinese": "你喜欢每天和我聊天",
 		"english": "You like to talk with me every day",
 		"soundmark": "/ju/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/ /'ɛvri/ /de/"
 	},
@@ -685,7 +685,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -695,7 +695,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "你必须告诉我事实因为它是重要的",
+		"chinese": "你必须告诉我事实，因为这是重要的",
 		"english": "You have to tell me the truth because it is important",
 		"soundmark": "/ju/ /hæv/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -715,22 +715,22 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "你想要知道是否它是重要的",
+		"chinese": "你想要知道这是否重要",
 		"english": "You want to know if it is important",
 		"soundmark": "/ju/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是可能的",
+		"chinese": "这是有可能的",
 		"english": "it is possible",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/"
 	},
 	{
-		"chinese": "你想要知道是否它是可能的",
+		"chinese": "你想要知道这是否有可能",
 		"english": "You want to know if it is possible",
 		"soundmark": "/ju/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /'pɑsəbl/"
 	},

--- a/packages/xingrong-courses/data/courses/03.json
+++ b/packages/xingrong-courses/data/courses/03.json
@@ -120,7 +120,7 @@
 		"soundmark": "/ʃi/ /nidz/"
 	},
 	{
-		"chinese": "她需要现在吃这个食物",
+		"chinese": "她现在需要吃这个食物",
 		"english": "she needs to eat the food now",
 		"soundmark": "/ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -135,7 +135,7 @@
 		"soundmark": "/ɪt/ /nidz/"
 	},
 	{
-		"chinese": "它需要现在吃这个食物",
+		"chinese": "它现在需要吃这个食物",
 		"english": "it needs to eat the food now",
 		"soundmark": "/ɪt/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某件事",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -190,7 +190,7 @@
 		"soundmark": "/tə/ /tɛl/ /ju/"
 	},
 	{
-		"chinese": "告诉你重要的某件事",
+		"chinese": "告诉你一些重要的事情",
 		"english": "to tell you something important",
 		"soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -200,7 +200,7 @@
 		"soundmark": "/aɪ/ /wɑnt/"
 	},
 	{
-		"chinese": "我想要告诉你重要的某件事",
+		"chinese": "我想要告诉你一些重要的事情",
 		"english": "I want to tell you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -210,7 +210,7 @@
 		"soundmark": "/ju/ /wɑnt/"
 	},
 	{
-		"chinese": "你想要告诉我重要的某件事",
+		"chinese": "你想告诉我一些重要的事情",
 		"english": "you want to tell me something important",
 		"soundmark": "/ju/ /wɑnt/ /tə/ /tɛl/ /mi/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -220,7 +220,7 @@
 		"soundmark": "/hi/ /wɑnts/"
 	},
 	{
-		"chinese": "他想要告诉我重要的某件事",
+		"chinese": "他想告诉我一些重要的事情",
 		"english": "he wants to tell me something important",
 		"soundmark": "/hi/ /wɑnts/ /tə/ /tɛl/ /mi/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -275,7 +275,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她想要解释原因为什么她现在需要吃这个食物",
+		"chinese": "她想要解释为什么她现在需要吃这个食物的原因",
 		"english": "she wants to explain the reason why she needs to eat the food now",
 		"soundmark": "/ʃi/ /wɑnts/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -385,12 +385,12 @@
 		"soundmark": "/ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "它是不可能的",
+		"chinese": "这是不可能的",
 		"english": "it is impossible",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "星荣想要在天空中飞翔但是它是不可能的",
+		"chinese": "星荣想要在天空中飞翔，但这是不可能的",
 		"english": "Xingrong wants to fly in the sky but it is impossible",
 		"soundmark": "/wɑnts/ /tə/ /flaɪ/ /ɪn/ /ðə/ /skaɪ/ /bət/ /ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
@@ -615,7 +615,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读",
+		"chinese": "她必须解释为什么她喜欢在家里阅读的原因",
 		"english": "she has to explain the reason why she likes to read at home",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/"
 	},
@@ -685,7 +685,7 @@
 		"soundmark": "/bɪ'kɔz/ /hi/ /ɪz/ /ˈvɛri/ /taɪrd/"
 	},
 	{
-		"chinese": "星荣现在必须睡觉因为他是非常劳累的",
+		"chinese": "星荣现在必须睡觉因为他非常疲倦",
 		"english": "Xingrong has to sleep now because he is very tired",
 		"soundmark": "/hæz/ /tə/ /slip/ /naʊ/ /bɪ'kɔz/ /hi/ /ɪz/ /ˈvɛri/ /taɪrd/"
 	},
@@ -765,7 +765,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读",
+		"chinese": "她必须解释为什么她喜欢在家里阅读的原因",
 		"english": "she has to explain the reason why she likes to read at home",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/"
 	},
@@ -780,7 +780,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -790,7 +790,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读因为它是非常重要的",
+		"chinese": "她必须解释为什么她喜欢在家阅读，因为这非常重要",
 		"english": "she has to explain the reason why she likes to read at home because it is very important",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},

--- a/packages/xingrong-courses/data/courses/04.json
+++ b/packages/xingrong-courses/data/courses/04.json
@@ -40,7 +40,7 @@
 		"soundmark": "/nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -50,7 +50,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不重要的所以我今天不需要做这件事",
+		"chinese": "这并不重要，所以我今天不需要做这件事",
 		"english": "it is not important so I don't need to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /so/ /aɪ/ /dont/ /nid/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -85,7 +85,7 @@
 		"soundmark": "/'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是紧急的",
+		"chinese": "这是紧急的",
 		"english": "it is urgent",
 		"soundmark": "/ɪt/ /ɪz/ /'ɝdʒənt/"
 	},
@@ -95,7 +95,7 @@
 		"soundmark": "/ənd/"
 	},
 	{
-		"chinese": "它是紧急的而且你需要现在做这件事",
+		"chinese": "这是紧急的，你需要现在就去做",
 		"english": "it is urgent and you need to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /'ɝdʒənt/ /ənd/ /ju/ /nid/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -200,7 +200,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我需要知道是否他想要做这件事",
+		"chinese": "我需要知道他是否想要做这件事",
 		"english": "I need to know if he wants to do it",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /hi/ /wɑnts/ /tə/ /du/ /ɪt/"
 	},
@@ -220,12 +220,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "他不想做这件事因为它是不重要的",
+		"chinese": "他不想做这件事因为这并不重要",
 		"english": "he doesn't want to do it because it is not important",
 		"soundmark": "/hi/ /ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "它需要现在吃这个食物",
+		"chinese": "它现在需要吃这个食物",
 		"english": "it needs to eat the food now",
 		"soundmark": "/ɪt/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -425,17 +425,17 @@
 		"soundmark": "/tə/ /tɛl/ /mi/"
 	},
 	{
-		"chinese": "重要的某事",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "他想要告诉我重要的某事",
+		"chinese": "他想告诉我一些重要的事情",
 		"english": "he wants to tell me something important",
 		"soundmark": "/hi/ /wɑnts/ /tə/ /tɛl/ /mi/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "他不想告诉我重要的某件事",
+		"chinese": "他不想告诉我一些重要的事情",
 		"english": "he doesn't want to tell me something important",
 		"soundmark": "/hi/ /ˈdʌznt/ /wɑnt/ /tə/ /tɛl/ /mi/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},

--- a/packages/xingrong-courses/data/courses/05.json
+++ b/packages/xingrong-courses/data/courses/05.json
@@ -65,12 +65,12 @@
 		"soundmark": "/tə'mɔro/"
 	},
 	{
-		"chinese": "我可以明天在这里",
+		"chinese": "我明天可以在这里",
 		"english": "I can be here tomorrow",
 		"soundmark": "/aɪ/ /kæn/ /bi/ /hɪr/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我不可以明天在这里",
+		"chinese": "我明天不可以在这里",
 		"english": "I can not be here tomorrow",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /bi/ /hɪr/ /tə'mɔro/"
 	},
@@ -85,7 +85,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "他需要知道是否我可以明天在这里",
+		"chinese": "他需要知道明天我是否可以在这里",
 		"english": "he needs to know if I can be here tomorrow",
 		"soundmark": "/hi/ /nidz/ /tə/ /no/ /ɪf/ /aɪ/ /kæn/ /bi/ /hɪr/ /tə'mɔro/"
 	},
@@ -105,12 +105,12 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我可以现在吃这个食物",
+		"chinese": "我现在可以吃这个食物",
 		"english": "I can eat the food now",
 		"soundmark": "/aɪ/ /kæn/ /it/ /ðə/ /fud/ /naʊ/"
 	},
 	{
-		"chinese": "我不可以现在吃这个食物",
+		"chinese": "我现在不可以吃这个食物",
 		"english": "I can not eat the food now",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -125,7 +125,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否我可以现在吃这个食物",
+		"chinese": "我想要知道现在我是否可以吃这个食物",
 		"english": "I want to know if I can eat the food now",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /aɪ/ /kæn/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -170,7 +170,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我需要知道是否你可以告诉我事实",
+		"chinese": "我需要知道你是否可以告诉我事实",
 		"english": "I need to know if you can tell me the truth",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /tɛl/ /mi/ /ðə/ /trʊθ/"
 	},
@@ -190,7 +190,7 @@
 		"soundmark": "/ju/ /kæn/ /nɑt/ /hɛlp/ /mi/"
 	},
 	{
-		"chinese": "我需要知道是否你可以帮助我",
+		"chinese": "我需要知道你是否可以帮助我",
 		"english": "I need to know if you can help me",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /hɛlp/ /mi/"
 	},
@@ -235,7 +235,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "你需要告诉我原因为什么你不可以在家里阅读",
+		"chinese": "你需要告诉我为什么你不可以在家里阅读的原因",
 		"english": "you need to tell me the reason why you can not read at home",
 		"soundmark": "/ju/ /nid/ /tə/ /tɛl/ /mi/ /ðə/ /ˈrizən/ /waɪ/ /ju/ /kæn/ /nɑt/ /rid/ /ət/ /hom/"
 	},
@@ -255,12 +255,12 @@
 		"soundmark": "/'letɚ/"
 	},
 	{
-		"chinese": "他可以以后做这件事",
+		"chinese": "他可以稍后再做",
 		"english": "he can do it later",
 		"soundmark": "/hi/ /kæn/ /du/ /ɪt/ /'letɚ/"
 	},
 	{
-		"chinese": "他不可以以后做这件事",
+		"chinese": "他以后不能这样做",
 		"english": "he can not do it later",
 		"soundmark": "/hi/ /kæn/ /nɑt/ /du/ /ɪt/ /'letɚ/"
 	},
@@ -300,7 +300,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否他今晚可以和我说话",
+		"chinese": "我想知道他今晚能否和我说话",
 		"english": "I want to know if he can talk with me tonight",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /hi/ /kæn/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
@@ -345,7 +345,7 @@
 		"soundmark": "/hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
 	{
-		"chinese": "她可以解释原因为什么他今晚不可以和我说话",
+		"chinese": "她可以解释为什么他今晚不可以和我说话的原因",
 		"english": "she can explain the reason why he can not talk with me tonight",
 		"soundmark": "/ʃi/ /kæn/ /nɑt/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
@@ -530,12 +530,12 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "你应该现在帮助我",
+		"chinese": "你现在应该帮助我",
 		"english": "you should help me now",
 		"soundmark": "/ju/ /ʃʊd/ /hɛlp/ /mi/ /naʊ/"
 	},
 	{
-		"chinese": "你不应该现在帮助我",
+		"chinese": "你现在不应该帮助我",
 		"english": "you should not help me now",
 		"soundmark": "/ju/ /ʃʊd/ /nɑt/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -770,12 +770,12 @@
 		"soundmark": "/ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "我将会在未来告诉你事实",
+		"chinese": "我会在将来告诉你事实",
 		"english": "I will tell you the truth in the future",
 		"soundmark": "/aɪ/ /wɪl/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "我将不会在未来告诉你事实",
+		"chinese": "将来我不会告诉你事实",
 		"english": "I will not tell you the truth in the future",
 		"soundmark": "/aɪ/ /wɪl/ /nɑt/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
@@ -785,7 +785,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -795,7 +795,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不重要的所以我将会在未来告诉你事实",
+		"chinese": "这不重要，所以我会在将来告诉你事实",
 		"english": "it is not important so I will tell you the truth in the future",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /so/ /aɪ/ /wɪl/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
@@ -845,7 +845,7 @@
 		"soundmark": "/'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是不紧急的",
+		"chinese": "这不是紧急的",
 		"english": "it is not urgent",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /'ɝdʒənt/"
 	},
@@ -855,7 +855,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不紧急的所以我将会在下周解释原因",
+		"chinese": "这不是紧急的，所以我将会在下周解释原因",
 		"english": "it is not urgent so I will explain the reason next week",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /'ɝdʒənt/ /so/ /aɪ/ /wɪl/ /ɪk'splen/ /ðə/ /ˈrizən/ /nekst/ /wik/"
 	},

--- a/packages/xingrong-courses/data/courses/06.json
+++ b/packages/xingrong-courses/data/courses/06.json
@@ -35,7 +35,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -45,7 +45,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -55,12 +55,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为它是非常重要的",
+		"chinese": "因为这是非常重要的",
 		"english": "because it is very important",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我需要现在做这件事因为它是非常重要的",
+		"chinese": "我需要现在就做，因为这非常重要",
 		"english": "I need to do it now because it is very important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /du/ /ɪt/ /naʊ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -75,7 +75,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -105,7 +105,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须每天做这件事",
+		"chinese": "这对我来说非常重要，所以我必须每天做",
 		"english": "It is very important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -115,7 +115,7 @@
 		"soundmark": "/nɑt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -125,7 +125,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "它是不重要的对我来说",
+		"chinese": "这对我来说并不重要",
 		"english": "it is not important for me",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -160,7 +160,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不重要的对我来说所以我不必现在做这件事",
+		"chinese": "这对我来说并不重要，所以我现在不必做了",
 		"english": "It is not important for me so I don't have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /dont/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -185,7 +185,7 @@
 		"soundmark": "/'pɑsəbl/"
 	},
 	{
-		"chinese": "它是可能的",
+		"chinese": "这是有可能的",
 		"english": "it is possible",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "做这件事（它）是可能的",
+		"chinese": "做这件事是有可能的",
 		"english": "it is possible to do it",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/ /tə/ /du/ /ɪt/"
 	},
@@ -205,7 +205,7 @@
 		"soundmark": "/tə'de/"
 	},
 	{
-		"chinese": "今天做这件事（它）是可能的",
+		"chinese": "今天做这件事是有可能的",
 		"english": "it is possible to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /'pɑsəbl/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -260,7 +260,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否你可以和我说话",
+		"chinese": "我想要知道你是否可以和我说话",
 		"english": "I want to know if you can talk with me",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /tɔk/ /wɪð/ /mi/"
 	},
@@ -270,12 +270,12 @@
 		"soundmark": "/tə'naɪt/"
 	},
 	{
-		"chinese": "我想要知道是否你今晚可以和我说话",
+		"chinese": "我想要知道你今晚是否可以和我说话",
 		"english": "I want to know if you can talk with me tonight",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -290,7 +290,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -300,7 +300,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "我想要知道是否你今晚可以和我说话因为它是非常重要的对我来说",
+		"chinese": "我想知道你今晚能否和我谈谈，因为这对我非常重要",
 		"english": "I want to know if you can talk with me tonight because it is very important for me",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -330,12 +330,12 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某件事情",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我必须告诉你重要的某件事情",
+		"chinese": "我必须告诉你一些重要的事情",
 		"english": "I have to tell you something important",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -345,7 +345,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我必须现在告诉你重要的某件事情",
+		"chinese": "我现在必须告诉你一些重要的事情",
 		"english": "I have to tell you something important now",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/ /naʊ/"
 	},
@@ -355,12 +355,12 @@
 		"soundmark": "/'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是紧急的",
+		"chinese": "这是紧急的",
 		"english": "it is urgent",
 		"soundmark": "/ɪt/ /ɪz/ /'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是非常紧急的",
+		"chinese": "这是非常紧急的",
 		"english": "it is very urgent",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'ɝdʒənt/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "我必须现在告诉你重要的某件事情因为它是非常紧急的",
+		"chinese": "我现在必须告诉你一些重要的事情，因为这非常紧急",
 		"english": "I have to tell you something important now because it is very urgent",
 		"soundmark": "/aɪ/ /hæv/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/ /naʊ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'ɝdʒənt/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "你必须现在帮助我",
+		"chinese": "你现在必须帮助我",
 		"english": "you have to help me now",
 		"soundmark": "/ju/ /hæv/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -465,7 +465,7 @@
 		"soundmark": "/ˈvɛri/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -475,7 +475,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -485,7 +485,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以你必须现在帮助我",
+		"chinese": "这对我来说非常重要，所以你现在必须帮助我",
 		"english": "It is very important for me so you have to help me now",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /ju/ /hæv/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -515,7 +515,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须现在做这件事",
+		"chinese": "这对我来说非常重要，所以我必须现在就去做",
 		"english": "It is very important for me so I have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -545,7 +545,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "你需要告诉我事实因为它是非常重要的对我来说",
+		"chinese": "你需要告诉我事实，因为这对我来说非常重要",
 		"english": "You need to tell me the truth because it is very important for me",
 		"soundmark": "/ju/ /nid/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -595,7 +595,7 @@
 		"soundmark": "/ʃi/ /nidz/"
 	},
 	{
-		"chinese": "她需要现在吃这个食物",
+		"chinese": "她现在需要吃这个食物",
 		"english": "she needs to eat the food now",
 		"soundmark": "/ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -605,7 +605,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她想要解释原因为什么她需要现在吃这个食物",
+		"chinese": "她想要解释为什么她现在需要吃这个食物的原因",
 		"english": "She wants to explain the reason why she needs to eat the food now",
 		"soundmark": "/ʃi/ /wɑnts/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -665,12 +665,12 @@
 		"soundmark": "/ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "它是不可能的",
+		"chinese": "这是不可能的",
 		"english": "it is impossible",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "星荣想要在天空中飞翔但是这件事是不可能的",
+		"chinese": "星荣想要在天空中飞翔，但这是不可能的",
 		"english": "Xingrong wants to fly in the sky but it is impossible",
 		"soundmark": "/wɑnts/ /tə/ /flaɪ/ /ɪn/ /ðə/ /skaɪ/ /bət/ /ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
@@ -695,7 +695,7 @@
 		"soundmark": "/hi/ /hæz/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -705,7 +705,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "他必须告诉我事实因为它是非常重要的对我来说",
+		"chinese": "他必须告诉我事实，因为这对我来说非常重要",
 		"english": "he has to tell me the truth because it is very important for me",
 		"soundmark": "/hi/ /hæz/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -730,7 +730,7 @@
 		"soundmark": "/ənd/"
 	},
 	{
-		"chinese": "他必须告诉我事实因为它是非常重要的对我来说而且我需要知道这件事",
+		"chinese": "他必须告诉我事实，因为这对我来说非常重要，而且我需要知道事实",
 		"english": "He has to tell me the truth because it is very important for me and I need to know it",
 		"soundmark": "/hi/ /hæz/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /ənd/ /aɪ/ /nid/ /tə/ /no/ /ɪt/"
 	},
@@ -815,7 +815,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读",
+		"chinese": "她必须解释为什么她喜欢在家里阅读的原因",
 		"english": "she has to explain the reason why she likes to read at home",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/"
 	},
@@ -830,7 +830,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -840,7 +840,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读因为这件事是非常重要的",
+		"chinese": "她必须解释为什么她喜欢在家阅读，因为这非常重要",
 		"english": "She has to explain the reason why she likes to read at home because it is very important",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -865,12 +865,12 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "他想要现在做这件事",
+		"chinese": "他现在想要做这件事",
 		"english": "he wants to do it now",
 		"soundmark": "/hi/ /wɑnts/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
 	{
-		"chinese": "他不想现在做这件事",
+		"chinese": "他现在不想做这件事",
 		"english": "he doesn't want to do it now",
 		"soundmark": "/ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -880,12 +880,12 @@
 		"soundmark": "/'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是紧急的",
+		"chinese": "这是紧急的",
 		"english": "it is urgent",
 		"soundmark": "/ɪt/ /ɪz/ /'ɝdʒənt/"
 	},
 	{
-		"chinese": "它是不紧急的",
+		"chinese": "这不是紧急的",
 		"english": "it is not urgent",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /'ɝdʒənt/"
 	},
@@ -895,7 +895,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "他不想现在做这件事因为它是不紧急的",
+		"chinese": "他现在不想做这件事，因为这并不紧急",
 		"english": "He doesn't want to do it now because it is not urgent",
 		"soundmark": "/ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /nɑt/ /'ɝdʒənt/"
 	},
@@ -985,12 +985,12 @@
 		"soundmark": "/ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "我将会在未来告诉你事实",
+		"chinese": "我会在将来告诉你事实",
 		"english": "I will tell you the truth in the future",
 		"soundmark": "/aɪ/ /wɪl/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "我将不会在未来告诉你事实",
+		"chinese": "将来我不会告诉你事实",
 		"english": "I will not tell you the truth in the future",
 		"soundmark": "/aɪ/ /wɪl/ /nɑt/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
@@ -1000,7 +1000,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -1010,7 +1010,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不重要的所以我将会在未来告诉你事实",
+		"chinese": "这不重要，所以我会在将来告诉你事实",
 		"english": "it is not important so I will tell you the truth in the future",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /so/ /aɪ/ /wɪl/ /tɛl/ /ju/ /ðə/ /trʊθ/ /ɪn/ /ðə/ /'fjʊtʃɚ/"
 	},
@@ -1055,7 +1055,7 @@
 		"soundmark": "/hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
 	{
-		"chinese": "她可以解释原因为什么他今晚不可以和我说话",
+		"chinese": "她可以解释为什么他今晚不可以和我说话的原因",
 		"english": "She can explain the reason why he can not talk with me tonight",
 		"soundmark": "/ʃi/ /kæn/ /nɑt/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	}

--- a/packages/xingrong-courses/data/courses/07.json
+++ b/packages/xingrong-courses/data/courses/07.json
@@ -95,12 +95,12 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "我们喜欢在晚上在街头跳舞",
+		"chinese": "我们喜欢晚上在街上跳舞",
 		"english": "we like to dance in the street at night",
 		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
 	{
-		"chinese": "我们不喜欢在晚上在街头跳舞",
+		"chinese": "我们不喜欢晚上在街上跳舞",
 		"english": "we don't like to dance in the street at night",
 		"soundmark": "/wi/ /dont/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/ɪn/ /ðə/ /strit/"
 	},
 	{
-		"chinese": "你们不喜欢在街头和我一起跳舞",
+		"chinese": "你们不喜欢和我在街上跳舞",
 		"english": "you don't like to dance with me in the street",
 		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/"
 	},
@@ -185,7 +185,7 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "你们不喜欢在晚上在街头和我一起跳舞",
+		"chinese": "你们不喜欢晚上和我在街上跳舞",
 		"english": "you don't like to dance with me in the street at night",
 		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -200,7 +200,7 @@
 		"soundmark": "/wɪð/ /mi/"
 	},
 	{
-		"chinese": "和我说话",
+		"chinese": "和我聊聊",
 		"english": "to talk with me",
 		"soundmark": "/tə/ /tɔk/ /wɪð/ /mi/"
 	},
@@ -210,12 +210,12 @@
 		"soundmark": "/ðe/"
 	},
 	{
-		"chinese": "他们喜欢和我说话",
+		"chinese": "他们喜欢和我聊天",
 		"english": "they like to talk with me",
 		"soundmark": "/ðe/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
 	},
 	{
-		"chinese": "他们不喜欢和我说话",
+		"chinese": "他们不喜欢和我聊天",
 		"english": "they don't like to talk with me",
 		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
 	},
@@ -255,12 +255,12 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "他们喜欢在晚上和你一起在街头跳舞",
+		"chinese": "他们喜欢晚上和你在街上跳舞",
 		"english": "they like to dance with you in the street at night",
 		"soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
 	{
-		"chinese": "他们不喜欢在晚上和你一起在街头跳舞",
+		"chinese": "他们不喜欢晚上和你在街上跳舞",
 		"english": "they don't like to dance with you in the street at night",
 		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -295,7 +295,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我们只是想要知道是否他们喜欢在晚上和你一起在街头跳舞",
+		"chinese": "我们只想知道他们是否喜欢晚上和你在街上跳舞",
 		"english": "we just want to know if they like to dance with you in the street at night",
 		"soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -600,7 +600,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "你们需要尽快回答关于工作的问题因为它们是非常重要的",
+		"chinese": "你们需要尽快回答有关工作的问题，因为这些问题非常重要",
 		"english": "you need to answer the questions about the work as soon as possible because they are very important",
 		"soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/ /bɪ'kɔz/ /ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -895,7 +895,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+		"chinese": "你应该知道我们为什么不想吃来自这个餐厅的食物的原因",
 		"english": "you should know the reason why we don't want to eat the food from the restaurant",
 		"soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
 	},
@@ -905,7 +905,7 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我认为你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+		"chinese": "我认为你应该知道为什么我们不想吃来自这个餐厅的食物的原因",
 		"english": "I think you should know the reason why we don't want to eat the food from the restaurant",
 		"soundmark": "/aɪ/ /θɪŋk/ /ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
 	}

--- a/packages/xingrong-courses/data/courses/08.json
+++ b/packages/xingrong-courses/data/courses/08.json
@@ -100,7 +100,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "他们只是想要知道是否我打算和你一起待在这里",
+		"chinese": "他们只想知道我是否打算和你一起待在这里",
 		"english": "they just want to know if I plan to stay here with you",
 		"soundmark": "/ðe/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /aɪ/ /plæn/ /tə/ /ste/ /hɪr/ /wɪð/ /ju/"
 	},
@@ -120,7 +120,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "他们只是想要知道原因为什么我不打算和你一起待在这里",
+		"chinese": "他们只是想要知道为什么我不打算和你一起待在这里的原因",
 		"english": "they just want to know the reason why I don't plan to stay here with you",
 		"soundmark": "/ðe/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ðə/ /ˈrizən/ /waɪ/ /aɪ/ /dont/ /plæn/ /tə/ /ste/ /hɪr/ /wɪð/ /ju/"
 	},
@@ -570,7 +570,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否你打算为我支付账单",
+		"chinese": "我想要知道你是否打算为我支付账单",
 		"english": "I want to know if you plan to pay the bill for me",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /mi/"
 	},
@@ -610,7 +610,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "这件事是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -620,7 +620,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这件事是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -630,12 +630,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为这件事是非常重要的",
+		"chinese": "因为这是非常重要的",
 		"english": "because it is very important",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我打算为他支付账单因为这件事是非常重要的",
+		"chinese": "我打算为他支付账单因为这是非常重要的",
 		"english": "I plan to pay the bill for him because it is very important",
 		"soundmark": "/aɪ/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /hɪm/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -665,7 +665,7 @@
 		"soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "我打算为他支付账单因为这件事是非常重要的而且我需要做这件事",
+		"chinese": "我打算为他支付账单因为这是非常重要的而且我需要做这件事",
 		"english": "I plan to pay the bill for him because it is very important and I need to do it",
 		"soundmark": "/aɪ/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /hɪm/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /ənd/ /aɪ/ /nid/ /tə/ /du/ /ɪt/"
 	},

--- a/packages/xingrong-courses/data/courses/09.json
+++ b/packages/xingrong-courses/data/courses/09.json
@@ -10,7 +10,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某件事",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -25,7 +25,7 @@
 		"soundmark": "/tə/ /tɛl/ /ju/"
 	},
 	{
-		"chinese": "告诉你重要的某件事",
+		"chinese": "告诉你一些重要的事",
 		"english": "to tell you something important",
 		"soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -35,7 +35,7 @@
 		"soundmark": "/aɪ/ /nid/"
 	},
 	{
-		"chinese": "我需要告诉你重要的某件事",
+		"chinese": "我需要告诉你一些重要的事情",
 		"english": "I need to tell you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -50,12 +50,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "重要的某个东西",
+		"chinese": "一些重要的东西",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我需要给你重要的某个东西",
+		"chinese": "我需要给你一些重要的东西",
 		"english": "I need to give you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /ɡɪv/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -275,7 +275,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我可以给你我的电话号码如果你想要知道它",
+		"chinese": "如果你想知道，我可以给你我的电话号码",
 		"english": "I can give you my phone number if you want to know it",
 		"soundmark": "/aɪ/ /kæn/ /ɡɪv/ /ju/ /maɪ/ /fon/ /'nʌmbɚ/ /ɪf/ /ju/ /wɑnt/ /tə/ /no/ /ɪt/"
 	},
@@ -310,7 +310,7 @@
 		"soundmark": "/ju/ /dont/ /wɑnt/ /tə/ /no/ /ɪt/"
 	},
 	{
-		"chinese": "我将不会给你我的电话号码如果你不想知道它",
+		"chinese": "如果你不想知道，我将不会告诉你我的电话号码",
 		"english": "I will not give you my phone number if you don't want to know it",
 		"soundmark": "/aɪ/ /wɪl/ /nɑt/ /ɡɪv/ /ju/ /maɪ/ /fon/ /'nʌmbɚ/ /ɪf/ /ju/ /dont/ /wɑnt/ /tə/ /no/ /ɪt/"
 	},
@@ -440,7 +440,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "它是重要的对我来说",
+		"chinese": "这对我来说是重要的",
 		"english": "it is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -460,7 +460,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -470,12 +470,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为它是非常重要的对我来说",
+		"chinese": "因为这对我来说非常重要",
 		"english": "because it is very important for me",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "我希望你可以给我她的电话号码因为这件事是非常重要的对我来说",
+		"chinese": "我希望你可以给我她的电话号码，因为这对我来说非常重要",
 		"english": "I hope you can give me her phone number because it is very important for me",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /hɚ/ /fon/ /'nʌmbɚ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -515,17 +515,17 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "因为它是非常重要的对我来说",
+		"chinese": "因为这对我来说非常重要",
 		"english": "because it is very important for me",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "我希望你可以给我搭把手因为它是非常重要的对我来说",
+		"chinese": "我希望你能帮我一把，因为这对我来说非常重要",
 		"english": "I hope you can give me a hand because it is very important for me",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /ə/ /hænd/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -560,7 +560,7 @@
 		"soundmark": "/aɪ/ /nid/ /ju/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
 	{
-		"chinese": "我希望你可以给我搭把手因为它是非常重要的对我来说而且我需要你现在帮助我",
+		"chinese": "我希望你能帮我一把，因为这对我来说非常重要，我需要你现在帮助我",
 		"english": "I hope you can give me a hand because it is very important for me and I need you to help me now",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /ə/ /hænd/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /ənd/ /aɪ/ /nid/ /ju/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -620,7 +620,7 @@
 		"soundmark": "/ə'baʊt/ /maɪ/ /wɝk/"
 	},
 	{
-		"chinese": "我希望你可以给我关于我的工作的一些建议",
+		"chinese": "我希望你可以就我的工作给我一些建议",
 		"english": "I hope you can give me some advice about my work",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /maɪ/ /wɝk/"
 	},
@@ -650,7 +650,7 @@
 		"soundmark": "/ə'baʊt/ /jʊr/ /wɝk/"
 	},
 	{
-		"chinese": "我想要给你关于你的工作的一些建议",
+		"chinese": "我想就你的工作给你一些建议",
 		"english": "I want to give you some advice about your work",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ɡɪv/ /ju/ /səm/ /əd'vaɪs/ /ə'baʊt/ /jʊr/ /wɝk/"
 	},
@@ -665,7 +665,7 @@
 		"soundmark": "/ə'baʊt/ /maɪ/ /wɝk/"
 	},
 	{
-		"chinese": "我想要你给我关于我的工作的一些建议",
+		"chinese": "我想你就我的工作给我一些建议",
 		"english": "I want you to give me some advice about my work",
 		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /maɪ/ /wɝk/"
 	},
@@ -685,12 +685,12 @@
 		"soundmark": "/tə/ /ɡɪv/ /hɪm/"
 	},
 	{
-		"chinese": "你可以给他关于他的工作的一些建议",
+		"chinese": "你可以就他的工作给他一些建议",
 		"english": "you can give him some advice about his work",
 		"soundmark": "/ju/ /kæn/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /hɪz/ /wɝk/"
 	},
 	{
-		"chinese": "我希望你可以给他关于他的工作的一些建议",
+		"chinese": "我希望你可以就他的工作给他一些建议",
 		"english": "I hope you can give him some advice about his work",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /hɪz/ /wɝk/"
 	},
@@ -710,12 +710,12 @@
 		"soundmark": "/tə/ /ɡɪv/ /hɚ/"
 	},
 	{
-		"chinese": "我希望你可以给她关于她的工作的一些建议",
+		"chinese": "我希望你可以就她的工作给她一些建议",
 		"english": "I hope you can give her some advice about her work",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /hɚ/ /səm/ /əd'vaɪs/ /ə'baʊt/ /hɚ/ /wɝk/"
 	},
 	{
-		"chinese": "我希望她可以给我关于我的工作的一些建议",
+		"chinese": "我希望她可以就我的工作给我一些建议",
 		"english": "I hope she can give me some advice about my work",
 		"soundmark": "/aɪ/ /hop/ /ʃi/ /kæn/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /maɪ/ /wɝk/"
 	},

--- a/packages/xingrong-courses/data/courses/10.json
+++ b/packages/xingrong-courses/data/courses/10.json
@@ -160,7 +160,7 @@
 		"soundmark": "/wi/ /kæn/ /ɡɛt/ /ðɛr/ /ɑn/ /taɪm/"
 	},
 	{
-		"chinese": "我们不可以准时到达那里",
+		"chinese": "我们无法准时到达那里",
 		"english": "we can not get there on time",
 		"soundmark": "/wi/ /kæn/ /nɑt/ /ɡɛt/ /ðɛr/ /ɑn/ /taɪm/"
 	},
@@ -255,7 +255,7 @@
 		"soundmark": "/wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
 	{
-		"chinese": "不要忘记锁门当你离开家的时候",
+		"chinese": "当你离开家的时候不要忘记锁门",
 		"english": "don't forget to lock the door when you leave the house",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
@@ -280,7 +280,7 @@
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /lɑk/ /ðə/ /dɔr/"
 	},
 	{
-		"chinese": "记得锁门当你离开家的时候",
+		"chinese": "当你离开家的时候记得锁门",
 		"english": "remember to lock the door when you leave the house",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
@@ -340,12 +340,12 @@
 		"soundmark": "/wɛn/ /ʃi/ /ɡɛts/ /hɪr/"
 	},
 	{
-		"chinese": "记得告诉她事实当她到达这里的时候",
+		"chinese": "当她到达这里的时候记得告诉她事实",
 		"english": "remember to tell her the truth when she gets here",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /tɛl/ /hɚ/ /ðə/ /trʊθ/ /wɛn/ /ʃi/ /ɡɛts/ /hɪr/"
 	},
 	{
-		"chinese": "不要忘记告诉她事实当她到达这里的时候",
+		"chinese": "当她到达这里的时候不要忘记告诉她事实",
 		"english": "don't forget to tell her the truth when she gets here",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /tɛl/ /hɚ/ /ðə/ /trʊθ/ /wɛn/ /ʃi/ /ɡɛts/ /hɪr/"
 	},
@@ -385,12 +385,12 @@
 		"soundmark": "/wɛn/ /ju/ /liv/"
 	},
 	{
-		"chinese": "不要忘记支付账单当你离开的时候",
+		"chinese": "当你离开的时候不要忘记支付账单",
 		"english": "don't forget to pay the bill when you leave",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /pe/ /ðə/ /bɪl/ /wɛn/ /ju/ /liv/"
 	},
 	{
-		"chinese": "记得支付账单当你离开的时候",
+		"chinese": "当你离开的时候记得支付账单",
 		"english": "remember to pay the bill when you leave",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /pe/ /ðə/ /bɪl/ /wɛn/ /ju/ /liv/"
 	},
@@ -450,12 +450,12 @@
 		"soundmark": "/wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
 	{
-		"chinese": "记得做家务当你在家里的时候",
+		"chinese": "当你在家里的时候记得做家务",
 		"english": "remember to do the housework when you are at home",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /du/ /ðə/ /'haʊswɝk/ /wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
 	{
-		"chinese": "不要忘记做家务当你在家里的时候",
+		"chinese": "当你在家里的时候不要忘记做家务",
 		"english": "don't forget to do the housework when you are at home",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /du/ /ðə/ /'haʊswɝk/ /wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
@@ -530,12 +530,12 @@
 		"soundmark": "/bɪ'fɔr/ /ju/ /it/ /ðə/ /fud/"
 	},
 	{
-		"chinese": "不要忘记洗你的手在你吃食物之前",
+		"chinese": "在你吃食物之前不要忘记洗你的手",
 		"english": "don't forget to wash your hands before you eat the food",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /wɑʃ/ /jʊr/ /hænds/ /bɪ'fɔr/ /ju/ /it/ /ðə/ /fud/"
 	},
 	{
-		"chinese": "记得洗你的手在你吃食物之前",
+		"chinese": "在你吃食物之前记得洗你的手",
 		"english": "remember to wash your hands before you eat the food",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /wɑʃ/ /jʊr/ /hænds/ /bɪ'fɔr/ /ju/ /it/ /ðə/ /fud/"
 	},
@@ -605,7 +605,7 @@
 		"soundmark": "/wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
 	{
-		"chinese": "记得给我打电话当你回到家的时候",
+		"chinese": "当你回到家的时候记得给我打电话",
 		"english": "remember to call me when you get home",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /kɔl/ /mi/ /wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
@@ -615,7 +615,7 @@
 		"soundmark": "/dont/ /fɚ'ɡɛt/"
 	},
 	{
-		"chinese": "不要忘记给我打电话当你回到家的时候",
+		"chinese": "当你回到家的时候不要忘记给我打电话",
 		"english": "don't forget to call me when you get home",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /kɔl/ /mi/ /wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
@@ -645,12 +645,12 @@
 		"soundmark": "/wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
 	{
-		"chinese": "不要忘记打扫房间当你回到家的时候",
+		"chinese": "当你回到家的时候不要忘记打扫房间",
 		"english": "don't forget to clean the room when you get home",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /klin/ /ðə/ /rum/ /wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
 	{
-		"chinese": "记得打扫房间当你回到家的时候",
+		"chinese": "当你回到家的时候记得打扫房间",
 		"english": "remember to clean the room when you get home",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /klin/ /ðə/ /rum/ /wɛn/ /ju/ /ɡɛt/ /hom/"
 	},
@@ -720,12 +720,12 @@
 		"soundmark": "/aɪ/ /kæn/ /faɪnd/ /ðə/ /ki/ /tə/ /ðə/ /dɔr/"
 	},
 	{
-		"chinese": "我不能找到门的钥匙",
+		"chinese": "我找不到门的钥匙",
 		"english": "I can not find the key to the door",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /faɪnd/ /ðə/ /ki/ /tə/ /ðə/ /dɔr/"
 	},
 	{
-		"chinese": "我不能找到房子的钥匙",
+		"chinese": "我找不到房子的钥匙",
 		"english": "I can not find the key to the house",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /faɪnd/ /ðə/ /ki/ /tə/ /ðə/ /haʊs/"
 	},
@@ -755,7 +755,7 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我觉得我丢掉了门的钥匙",
+		"chinese": "我觉得我弄丢了门的钥匙",
 		"english": "I think I lost the key to the door",
 		"soundmark": "/aɪ/ /θɪŋk/ /aɪ/ /lɔst/ /ðə/ /ki/ /tə/ /ðə/ /dɔr/"
 	},
@@ -765,12 +765,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "我不能找到它",
+		"chinese": "我找不到它",
 		"english": "I can not find it",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /faɪnd/ /ɪt/"
 	},
 	{
-		"chinese": "我觉得我丢掉了门的钥匙因为我不能找到它",
+		"chinese": "我觉得我弄丢了门的钥匙因为我找不到它了",
 		"english": "I think I lost the key to the door because I can not find it",
 		"soundmark": "/aɪ/ /θɪŋk/ /aɪ/ /lɔst/ /ðə/ /ki/ /tə/ /ðə/ /dɔr/ /bɪ'kɔz/ /aɪ/ /kæn/ /nɑt/ /faɪnd/ /ɪt/"
 	},
@@ -840,12 +840,12 @@
 		"soundmark": "/wɛn/ /ju/ /liv/ /ðə/ /rum/"
 	},
 	{
-		"chinese": "不要忘记关闭窗户当你离开房间的时候",
+		"chinese": "当你离开房间的时候不要忘记关闭窗户",
 		"english": "don't forget to close the window when you leave the room",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /kloz/ /ðə/ /'wɪndo/ /wɛn/ /ju/ /liv/ /ðə/ /rum/"
 	},
 	{
-		"chinese": "记得关闭窗户当你离开房间的时候",
+		"chinese": "当你离开房间的时候记得关闭窗户",
 		"english": "remember to close the window when you leave the room",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /kloz/ /ðə/ /'wɪndo/ /wɛn/ /ju/ /liv/ /ðə/ /rum/"
 	}

--- a/packages/xingrong-courses/data/courses/11.json
+++ b/packages/xingrong-courses/data/courses/11.json
@@ -25,12 +25,12 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某些事情",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "告诉你重要的某些事情",
+		"chinese": "告诉你一些重要的事情",
 		"english": "to tell you something important",
 		"soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -40,7 +40,7 @@
 		"soundmark": "/wɑnt/"
 	},
 	{
-		"chinese": "我想要告诉你重要的某些事情",
+		"chinese": "我想要告诉你一些重要的事情",
 		"english": "I want to tell you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -55,12 +55,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "重要的某些东西",
+		"chinese": "一些重要的东西",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要教你重要的某些东西",
+		"chinese": "我想要教你一些重要的东西",
 		"english": "I want to teach you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -85,7 +85,7 @@
 		"soundmark": "/ə/ /'lɛsn/"
 	},
 	{
-		"chinese": "我想要教你一堂课",
+		"chinese": "我想要给你上一课",
 		"english": "I want to teach you a lesson",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
 	},
@@ -105,7 +105,7 @@
 		"soundmark": "/tə/ /titʃ/ /hɪm/"
 	},
 	{
-		"chinese": "你必须教他一堂课",
+		"chinese": "你必须给他上一课",
 		"english": "you have to teach him a lesson",
 		"soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /hɪm/ /ə/ /'lɛsn/"
 	},
@@ -255,7 +255,7 @@
 		"soundmark": "/tə/ /ʃo/"
 	},
 	{
-		"chinese": "展示给你",
+		"chinese": "向你展示",
 		"english": "to show you",
 		"soundmark": "/tə/ /ʃo/ /ju/"
 	},
@@ -265,12 +265,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "展示给你某些东西",
+		"chinese": "向你展示一些东西",
 		"english": "to show you something",
 		"soundmark": "/tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "我想要展示给你某些东西",
+		"chinese": "我想要向你展示一些东西",
 		"english": "I want to show you something",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
 	},
@@ -280,7 +280,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要展示给你重要的某些东西",
+		"chinese": "我想要向你展示一些重要的东西",
 		"english": "I want to show you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -290,7 +290,7 @@
 		"soundmark": "/'ɛnɪθɪŋ/"
 	},
 	{
-		"chinese": "我不想展示给你任何东西",
+		"chinese": "我不想向你展示任何东西",
 		"english": "I don't want to show you anything",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /ʃo/ /ju/ /'ɛnɪθɪŋ/"
 	},
@@ -300,12 +300,12 @@
 		"soundmark": "/mi/"
 	},
 	{
-		"chinese": "展示给我",
+		"chinese": "向我展示",
 		"english": "to show me",
 		"soundmark": "/tə/ /ʃo/ /mi/"
 	},
 	{
-		"chinese": "你必须展示给我",
+		"chinese": "你必须向我展示",
 		"english": "you have to show me",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
 	},
@@ -325,7 +325,7 @@
 		"soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
 	},
 	{
-		"chinese": "你必须展示给我如何使用字典",
+		"chinese": "你必须向我展示如何使用字典",
 		"english": "you have to show me how to use the dictionary",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
 	},
@@ -340,7 +340,7 @@
 		"soundmark": "/haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
 	},
 	{
-		"chinese": "你必须展示给我如何使用网络",
+		"chinese": "你必须向我展示如何使用网络",
 		"english": "you have to show me how to use the internet",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
 	},
@@ -355,17 +355,17 @@
 		"soundmark": "/haʊ/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "展示给我们",
+		"chinese": "向我们展示",
 		"english": "to show us",
 		"soundmark": "/tə/ /ʃo/ /ʌs/"
 	},
 	{
-		"chinese": "你需要展示给我们如何做这件事",
+		"chinese": "你需要向我们展示如何做这件事",
 		"english": "you need to show us how to do it",
 		"soundmark": "/ju/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "你不需要展示给我们如何做这件事",
+		"chinese": "你不需要向我们展示如何做这件事",
 		"english": "you don't need to show us how to do it",
 		"soundmark": "/ju/ /dont/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
 	},
@@ -395,17 +395,17 @@
 		"soundmark": "/jʊr/ /nu/ /haʊs/"
 	},
 	{
-		"chinese": "你必须展示给我",
+		"chinese": "你必须向我展示",
 		"english": "you have to show me",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
 	},
 	{
-		"chinese": "你必须展示给我你的新房子",
+		"chinese": "你必须向我展示你的新房子",
 		"english": "you have to show me your new house",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
 	},
 	{
-		"chinese": "你不必展示给我你的新房子",
+		"chinese": "你不必向我展示你的新房子",
 		"english": "you don't have to show me your new house",
 		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
 	},
@@ -420,12 +420,12 @@
 		"soundmark": "/jʊr/ /hændz/"
 	},
 	{
-		"chinese": "展示给我你的手",
+		"chinese": "向我展示你的手",
 		"english": "to show me your hands",
 		"soundmark": "/tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
 	},
 	{
-		"chinese": "你必须展示给我你的手",
+		"chinese": "你必须向我展示你的手",
 		"english": "you have to show me your hands",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
 	},
@@ -570,7 +570,7 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面",
+		"chinese": "我不想让你晚上外出",
 		"english": "I don't want to let you go out at night",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/"
 	},
@@ -590,17 +590,17 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这件事是非常危险的",
+		"chinese": "这是非常危险的",
 		"english": "it is very dangerous",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
 	{
-		"chinese": "因为这件事是非常危险的",
+		"chinese": "因为这是非常危险的",
 		"english": "because it is very dangerous",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的",
+		"chinese": "我不想让你晚上外出因为这是非常危险的",
 		"english": "I don't want to let you go out at night because it is very dangerous",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
@@ -640,7 +640,7 @@
 		"soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的而且我需要你待在这里",
+		"chinese": "我不想让你晚上外出因为这是非常危险的而且我需要你待在这里",
 		"english": "I don't want to let you go out at night because it is very dangerous and I need you to stay here",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/ /ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
 	},
@@ -725,7 +725,7 @@
 		"soundmark": "/wɛn/ /wi/ /ɡɛt/ /ðɛr/"
 	},
 	{
-		"chinese": "你必须记得当我们到达那里的时候让我打电话给我的父亲",
+		"chinese": "当我们到达那里的时候你一定要记得让我打电话给我的父亲",
 		"english": "you have to remember to let me call my father when we get there",
 		"soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/ /wɛn/ /wi/ /ɡɛt/ /ðɛr/"
 	},
@@ -835,7 +835,7 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "让我告诉你某些事情",
+		"chinese": "让我告诉你一些事情",
 		"english": "let me tell you something",
 		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/"
 	},
@@ -855,7 +855,7 @@
 		"soundmark": "/ə'baʊt/ /jʊr/ /wɝk/"
 	},
 	{
-		"chinese": "让我告诉你关于你的工作的某些事情",
+		"chinese": "让我告诉你关于你的工作的一些事情",
 		"english": "let me tell you something about your work",
 		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ə'baʊt/ /jʊr/ /wɝk/"
 	},

--- a/packages/xingrong-courses/data/courses/12.json
+++ b/packages/xingrong-courses/data/courses/12.json
@@ -80,17 +80,17 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某些事情",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我需要告诉你某些事情",
+		"chinese": "我需要告诉你一些事情",
 		"english": "I need to tell you something",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "我需要告诉你重要的某些事情",
+		"chinese": "我需要告诉你一些重要的事情",
 		"english": "I need to tell you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -100,7 +100,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -110,7 +110,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "It is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -125,12 +125,12 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是重要的",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是非常重要的",
+		"chinese": "这对我来说非常重要",
 		"english": "It is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -150,12 +150,12 @@
 		"soundmark": "/tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里（它）是好的",
+		"chinese": "来到这里真好",
 		"english": "It is good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "来到这里（它）是非常好的",
+		"chinese": "来到这里非常好",
 		"english": "It is very good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
@@ -165,7 +165,7 @@
 		"soundmark": "/tə/ /si/ /ju/"
 	},
 	{
-		"chinese": "见到你（它）是非常好的",
+		"chinese": "很高兴见到你",
 		"english": "It is very good to see you",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /si/ /ju/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "每天见到你（它）是非常好的",
+		"chinese": "每天都能见到你真是太好了",
 		"english": "It is very good to see you every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɡʊd/ /tə/ /si/ /ju/ /'ɛvri/ /de/"
 	},
@@ -195,17 +195,17 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否它是可能的",
+		"chinese": "我想要知道是否有可能",
 		"english": "I want to know if it is possible",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /'pɑsəbl/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要知道是否它是重要的",
+		"chinese": "我想要知道这是否是重要的",
 		"english": "I want to know if it is important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -215,7 +215,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "对我来说它是重要的",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -240,12 +240,12 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我必须做这件事",
+		"chinese": "这对我来说是重要的，所以我必须这么做",
 		"english": "It is important for me so I have to do it",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我今天必须做这件事",
+		"chinese": "这对我来说是重要的，所以我必须今天就做",
 		"english": "It is important for me so I have to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -255,7 +255,7 @@
 		"soundmark": "/'ɛvri/ /de/"
 	},
 	{
-		"chinese": "它是重要的对我来说所以我必须每天做这件事",
+		"chinese": "这对我来说是重要的，所以我必须每天做",
 		"english": "It is important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -265,7 +265,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须每天做这件事",
+		"chinese": "这对我来说非常重要，所以我必须每天做",
 		"english": "It is very important for me so I have to do it every day",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /'ɛvri/ /de/"
 	},
@@ -275,7 +275,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说所以我必须现在做这件事",
+		"chinese": "这对我来说非常重要，所以我必须现在就去做",
 		"english": "It is very important for me so I have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -285,12 +285,12 @@
 		"soundmark": "/nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "It is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的对我来说",
+		"chinese": "这对我来说并不重要",
 		"english": "It is not important for me",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -320,7 +320,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它不是重要的对我来说所以我不必现在做这件事情",
+		"chinese": "这对我来说并不重要，所以我现在不必做了",
 		"english": "It is not important for me so I don't have to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /so/ /aɪ/ /dont/ /hæv/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -335,7 +335,7 @@
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
 	{
-		"chinese": "我需要告诉你重要的某些事情",
+		"chinese": "我需要告诉你一些重要的事情",
 		"english": "I need to tell you something important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -345,17 +345,17 @@
 		"soundmark": "/aɪ/ /hæv/ /tə/ /no/ /ju/ /sun/"
 	},
 	{
-		"chinese": "来到这里（它）是好的",
+		"chinese": "来到这里真好",
 		"english": "It is good to be here",
 		"soundmark": "/ɪt/ /ɪz/ /ɡʊd/ /tə/ /bi/ /hɪr/"
 	},
 	{
-		"chinese": "它是重要的对我来说",
+		"chinese": "这对我来说是重要的",
 		"english": "It is important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "现在做这件事情（它）是不可能的",
+		"chinese": "现在不可能做到",
 		"english": "It is impossible to do it now",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/ /tə/ /du/ /ɪt/ /naʊ/"
 	},
@@ -395,7 +395,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否我是重要的",
+		"chinese": "我想要知道我是否重要",
 		"english": "I want to know if I am important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /ɪm'pɔrtnt/"
 	},
@@ -405,7 +405,7 @@
 		"soundmark": "/nid/ /tə/ /no/"
 	},
 	{
-		"chinese": "我需要知道是否我是重要的",
+		"chinese": "我需要知道我是否重要",
 		"english": "I need to know if I am important",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /aɪ/ /æm/ /ɪm'pɔrtnt/"
 	},
@@ -445,7 +445,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "It is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "你必须告诉我事实因为它是重要的",
+		"chinese": "你必须告诉我事实，因为这是重要的",
 		"english": "You have to tell me the truth because it is important",
 		"soundmark": "/ju/ /hæv/ /tə/ /tɛl/ /mi/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -470,7 +470,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某件事",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -485,7 +485,7 @@
 		"soundmark": "/tə/ /tɛl/ /ju/"
 	},
 	{
-		"chinese": "告诉你重要的某件事",
+		"chinese": "告诉你一些重要的事情",
 		"english": "to tell you something important",
 		"soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -495,7 +495,7 @@
 		"soundmark": "/aɪ/ /wɑnt/"
 	},
 	{
-		"chinese": "我想要告诉你重要的某件事",
+		"chinese": "我想要告诉你一些重要的事情",
 		"english": "I want to tell you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -530,7 +530,7 @@
 		"soundmark": "/ʃi/ /nidz/"
 	},
 	{
-		"chinese": "她需要现在吃这个食物",
+		"chinese": "她现在需要吃这个食物",
 		"english": "she needs to eat the food now",
 		"soundmark": "/ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -565,7 +565,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "她想要解释原因为什么她现在需要吃这个食物",
+		"chinese": "她想要解释为什么她现在需要吃这个食物的原因",
 		"english": "she wants to explain the reason why she needs to eat the food now",
 		"soundmark": "/ʃi/ /wɑnts/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /nidz/ /tə/ /it/ /ðə/ /fud/ /naʊ/"
 	},
@@ -590,7 +590,7 @@
 		"soundmark": "/ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读",
+		"chinese": "她必须解释为什么她喜欢在家里阅读的原因",
 		"english": "she has to explain the reason why she likes to read at home",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/"
 	},
@@ -605,7 +605,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -615,7 +615,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "她必须解释原因为什么她喜欢在家里阅读因为它是非常重要的",
+		"chinese": "她必须解释为什么她喜欢在家阅读，因为这非常重要",
 		"english": "she has to explain the reason why she likes to read at home because it is very important",
 		"soundmark": "/ʃi/ /hæz/ /tə/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /ʃi/ /laɪks/ /tə/ /rid/ /ət/ /hom/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -725,12 +725,12 @@
 		"soundmark": "/ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "它是不可能的",
+		"chinese": "这是不可能的",
 		"english": "it is impossible",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
 	{
-		"chinese": "星荣想要在天空中飞翔但是它是不可能的",
+		"chinese": "星荣想要在天空中飞翔，但这是不可能的",
 		"english": "Xingrong wants to fly in the sky but it is impossible",
 		"soundmark": "/wɑnts/ /tə/ /flaɪ/ /ɪn/ /ðə/ /skaɪ/ /bət/ /ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},
@@ -820,7 +820,7 @@
 		"soundmark": "/nɑt/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是不重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -830,7 +830,7 @@
 		"soundmark": "/so/"
 	},
 	{
-		"chinese": "它是不重要的所以我今天不需要做这件事",
+		"chinese": "这并不重要，所以我今天不需要做这件事",
 		"english": "it is not important so I don't need to do it today",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /so/ /aɪ/ /dont/ /nid/ /tə/ /du/ /ɪt/ /tə'de/"
 	},
@@ -900,12 +900,12 @@
 		"soundmark": "/tə'mɔro/"
 	},
 	{
-		"chinese": "我可以明天在这里",
+		"chinese": "我明天可以在这里",
 		"english": "I can be here tomorrow",
 		"soundmark": "/aɪ/ /kæn/ /bi/ /hɪr/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我不可以明天在这里",
+		"chinese": "我明天不可以在这里",
 		"english": "I can not be here tomorrow",
 		"soundmark": "/aɪ/ /kæn/ /nɑt/ /bi/ /hɪr/ /tə'mɔro/"
 	},
@@ -920,7 +920,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "他需要知道是否我可以明天在这里",
+		"chinese": "他需要知道明天我是否可以在这里",
 		"english": "he needs to know if I can be here tomorrow",
 		"soundmark": "/hi/ /nidz/ /tə/ /no/ /ɪf/ /aɪ/ /kæn/ /bi/ /hɪr/ /tə'mɔro/"
 	},
@@ -965,7 +965,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我需要知道是否你可以告诉我事实",
+		"chinese": "我需要知道你是否可以告诉我事实",
 		"english": "I need to know if you can tell me the truth",
 		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /tɛl/ /mi/ /ðə/ /trʊθ/"
 	},
@@ -1010,7 +1010,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "你需要告诉我原因为什么你不可以在家里阅读",
+		"chinese": "你需要告诉我为什么你不可以在家里阅读的原因",
 		"english": "you need to tell me the reason why you can not read at home",
 		"soundmark": "/ju/ /nid/ /tə/ /tɛl/ /mi/ /ðə/ /ˈrizən/ /waɪ/ /ju/ /kæn/ /nɑt/ /rid/ /ət/ /hom/"
 	},
@@ -1050,7 +1050,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否他今晚可以和我说话",
+		"chinese": "我想知道他今晚能否和我说话",
 		"english": "I want to know if he can talk with me tonight",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /hi/ /kæn/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
@@ -1095,7 +1095,7 @@
 		"soundmark": "/hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
 	{
-		"chinese": "她可以解释原因为什么他今晚不可以和我说话",
+		"chinese": "她可以解释为什么他今晚不可以和我说话的原因",
 		"english": "she can explain the reason why he can not talk with me tonight",
 		"soundmark": "/ʃi/ /kæn/ /nɑt/ /ɪk'splen/ /ðə/ /ˈrizən/ /waɪ/ /hi/ /kæn/ /nɑt/ /tɔk/ /wɪð/ /mi/ /tə'naɪt/"
 	},
@@ -1140,12 +1140,12 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "我们喜欢在晚上在街头跳舞",
+		"chinese": "我们喜欢晚上在街上跳舞",
 		"english": "we like to dance in the street at night",
 		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
 	{
-		"chinese": "我们不喜欢在晚上在街头跳舞",
+		"chinese": "我们不喜欢晚上在街上跳舞",
 		"english": "we don't like to dance in the street at night",
 		"soundmark": "/wi/ /dont/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -1155,7 +1155,7 @@
 		"soundmark": "/ðe/"
 	},
 	{
-		"chinese": "他们不喜欢在晚上和你一起在街头跳舞",
+		"chinese": "他们不喜欢晚上和你在街上跳舞",
 		"english": "they don't like to dance with you in the street at night",
 		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -1190,7 +1190,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我们只是想要知道是否他们喜欢在晚上和你一起在街头跳舞",
+		"chinese": "我们只想知道他们是否喜欢晚上和你在街上跳舞",
 		"english": "we just want to know if they like to dance with you in the street at night",
 		"soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
 	},
@@ -1360,7 +1360,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "你们需要尽快回答关于工作的问题因为它们是非常重要的",
+		"chinese": "你们需要尽快回答有关工作的问题，因为这些问题非常重要",
 		"english": "you need to answer the questions about the work as soon as possible because they are very important",
 		"soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/ /bɪ'kɔz/ /ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -1495,7 +1495,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+		"chinese": "你应该知道我们为什么不想吃来自这个餐厅的食物的原因",
 		"english": "you should know the reason why we don't want to eat the food from the restaurant",
 		"soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
 	},
@@ -1505,7 +1505,7 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我认为你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+		"chinese": "我认为你应该知道为什么我们不想吃来自这个餐厅的食物的原因",
 		"english": "I think you should know the reason why we don't want to eat the food from the restaurant",
 		"soundmark": "/aɪ/ /θɪŋk/ /ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
 	},
@@ -1585,7 +1585,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "他们只是想要知道是否我打算和你一起待在这里",
+		"chinese": "他们只想知道我是否打算和你一起待在这里",
 		"english": "they just want to know if I plan to stay here with you",
 		"soundmark": "/ðe/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /aɪ/ /plæn/ /tə/ /ste/ /hɪr/ /wɪð/ /ju/"
 	},
@@ -1605,7 +1605,7 @@
 		"soundmark": "/waɪ/"
 	},
 	{
-		"chinese": "他们只是想要知道原因为什么我不打算和你一起待在这里",
+		"chinese": "他们只是想要知道为什么我不打算和你一起待在这里的原因",
 		"english": "they just want to know the reason why I don't plan to stay here with you",
 		"soundmark": "/ðe/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ðə/ /ˈrizən/ /waɪ/ /aɪ/ /dont/ /plæn/ /tə/ /ste/ /hɪr/ /wɪð/ /ju/"
 	},
@@ -1755,7 +1755,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "我想要知道是否你打算为我支付账单",
+		"chinese": "我想要知道你是否打算为我支付账单",
 		"english": "I want to know if you plan to pay the bill for me",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /mi/"
 	},
@@ -1785,7 +1785,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "这件事是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -1795,7 +1795,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这件事是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -1805,12 +1805,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为这件事是非常重要的",
+		"chinese": "因为这是非常重要的",
 		"english": "because it is very important",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我打算为他支付账单因为这件事是非常重要的",
+		"chinese": "我打算为他支付账单因为这是非常重要的",
 		"english": "I plan to pay the bill for him because it is very important",
 		"soundmark": "/aɪ/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /hɪm/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
@@ -1840,7 +1840,7 @@
 		"soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /du/ /ɪt/"
 	},
 	{
-		"chinese": "我打算为他支付账单因为这件事是非常重要的而且我需要做这件事",
+		"chinese": "我打算为他支付账单因为这是非常重要的而且我需要做这件事",
 		"english": "I plan to pay the bill for him because it is very important and I need to do it",
 		"soundmark": "/aɪ/ /plæn/ /tə/ /pe/ /ðə/ /bɪl/ /fɝ/ /hɪm/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /ənd/ /aɪ/ /nid/ /tə/ /du/ /ɪt/"
 	},
@@ -2050,17 +2050,17 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "它是非常重要的对我来说",
+		"chinese": "这对我来说非常重要",
 		"english": "it is very important for me",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "因为它是非常重要的对我来说",
+		"chinese": "因为这对我来说非常重要",
 		"english": "because it is very important for me",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "我希望你可以给我搭把手因为它是非常重要的对我来说",
+		"chinese": "我希望你能帮我一把，因为这对我来说非常重要",
 		"english": "I hope you can give me a hand because it is very important for me",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /ə/ /hænd/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/"
 	},
@@ -2095,7 +2095,7 @@
 		"soundmark": "/aɪ/ /nid/ /ju/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
 	{
-		"chinese": "我希望你可以给我搭把手因为它是非常重要的对我来说而且我需要你现在帮助我",
+		"chinese": "我希望你能帮我一把，因为这对我来说非常重要，我需要你现在帮助我",
 		"english": "I hope you can give me a hand because it is very important for me and I need you to help me now",
 		"soundmark": "/aɪ/ /hop/ /ju/ /kæn/ /ɡɪv/ /mi/ /ə/ /hænd/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /fɝ/ /mi/ /ənd/ /aɪ/ /nid/ /ju/ /tə/ /hɛlp/ /mi/ /naʊ/"
 	},
@@ -2310,7 +2310,7 @@
 		"soundmark": "/wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
 	{
-		"chinese": "不要忘记锁门当你离开家的时候",
+		"chinese": "当你离开家的时候不要忘记锁门",
 		"english": "don't forget to lock the door when you leave the house",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
@@ -2335,7 +2335,7 @@
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /lɑk/ /ðə/ /dɔr/"
 	},
 	{
-		"chinese": "记得锁门当你离开家的时候",
+		"chinese": "当你离开家的时候记得锁门",
 		"english": "remember to lock the door when you leave the house",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ju/ /liv/ /ðə/ /haʊs/"
 	},
@@ -2395,12 +2395,12 @@
 		"soundmark": "/wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
 	{
-		"chinese": "记得做家务当你在家里的时候",
+		"chinese": "当你在家里的时候记得做家务",
 		"english": "remember to do the housework when you are at home",
 		"soundmark": "/rɪ'mɛmbɚ/ /tə/ /du/ /ðə/ /'haʊswɝk/ /wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
 	{
-		"chinese": "不要忘记做家务当你在家里的时候",
+		"chinese": "当你在家里的时候不要忘记做家务",
 		"english": "don't forget to do the housework when you are at home",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /du/ /ðə/ /'haʊswɝk/ /wɛn/ /ju/ /ɚ/ /ət/ /hom/"
 	},
@@ -2415,12 +2415,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "重要的某些东西",
+		"chinese": "一些重要的东西",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要教你重要的某些东西",
+		"chinese": "我想要教你一些重要的东西",
 		"english": "I want to teach you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -2480,7 +2480,7 @@
 		"soundmark": "/tə/ /ʃo/"
 	},
 	{
-		"chinese": "展示给你",
+		"chinese": "向你展示",
 		"english": "to show you",
 		"soundmark": "/tə/ /ʃo/ /ju/"
 	},
@@ -2490,12 +2490,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "展示给你某些东西",
+		"chinese": "向你展示一些东西",
 		"english": "to show you something",
 		"soundmark": "/tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "我想要展示给你某些东西",
+		"chinese": "我想要向你展示一些东西",
 		"english": "I want to show you something",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
 	},
@@ -2505,7 +2505,7 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要展示给你重要的某些东西",
+		"chinese": "我想要向你展示一些重要的东西",
 		"english": "I want to show you something important",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -2525,7 +2525,7 @@
 		"soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
 	},
 	{
-		"chinese": "你必须展示给我如何使用字典",
+		"chinese": "你必须向我展示如何使用字典",
 		"english": "you have to show me how to use the dictionary",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
 	},
@@ -2620,7 +2620,7 @@
 		"soundmark": "/nɛkst/ /wik/"
 	},
 	{
-		"chinese": "我下周将会让你知道关于我的事实",
+		"chinese": "下周我将会让你知道关于我的事实",
 		"english": "I will let you know the truth about me next week",
 		"soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/ /nɛkst/ /wik/"
 	},
@@ -2670,7 +2670,7 @@
 		"soundmark": "/ət/ /naɪt/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面",
+		"chinese": "我不想让你晚上外出",
 		"english": "I don't want to let you go out at night",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/"
 	},
@@ -2690,17 +2690,17 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "这件事是非常危险的",
+		"chinese": "这是非常危险的",
 		"english": "it is very dangerous",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
 	{
-		"chinese": "因为这件事是非常危险的",
+		"chinese": "因为这是非常危险的",
 		"english": "because it is very dangerous",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的",
+		"chinese": "我不想让你晚上外出因为这是非常危险的",
 		"english": "I don't want to let you go out at night because it is very dangerous",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
 	},
@@ -2740,7 +2740,7 @@
 		"soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
 	},
 	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的而且我需要你待在这里",
+		"chinese": "我不想让你晚上外出因为这是非常危险的而且我需要你待在这里",
 		"english": "I don't want to let you go out at night because it is very dangerous and I need you to stay here",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/ /ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
 	},
@@ -2825,7 +2825,7 @@
 		"soundmark": "/wɛn/ /wi/ /ɡɛt/ /ðɛr/"
 	},
 	{
-		"chinese": "你必须记得当我们到达那里的时候让我打电话给我的父亲",
+		"chinese": "当我们到达那里的时候你一定要记得让我打电话给我的父亲",
 		"english": "you have to remember to let me call my father when we get there",
 		"soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/ /wɛn/ /wi/ /ɡɛt/ /ðɛr/"
 	}

--- a/packages/xingrong-courses/data/courses/13.json
+++ b/packages/xingrong-courses/data/courses/13.json
@@ -440,12 +440,12 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它（过去）是重要的",
+		"chinese": "这（过去）是重要的",
 		"english": "it was important",
 		"soundmark": "/ɪt/ /wəz/ /ɪm'pɔrtnt/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为它（过去）是重要的",
+		"chinese": "因为这（过去）是重要的",
 		"english": "because it was important",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
 	},
@@ -465,7 +465,7 @@
 		"soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
 	},
 	{
-		"chinese": "他（过去）告诉我他（过去）需要知道真相因为它（过去）是重要的",
+		"chinese": "他（过去）告诉我他（过去）需要知道真相因为这（过去）是重要的",
 		"english": "he told me he needed to know the truth because it was important",
 		"soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
 	},
@@ -525,7 +525,7 @@
 		"soundmark": "/wɛn/"
 	},
 	{
-		"chinese": "当我（过去）是年轻的时候",
+		"chinese": "当我（过去）年轻的时候",
 		"english": "when I was young",
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /jʌŋ/"
 	},
@@ -535,7 +535,7 @@
 		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/"
 	},
 	{
-		"chinese": "我（过去）想要成为一个老师当我（过去）是年轻的时候",
+		"chinese": "我（过去）想要成为一个老师当我（过去）年轻的时候",
 		"english": "I wanted to be a teacher when I was young",
 		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/ /wɛn/ /aɪ/ /wəz/ /jʌŋ/"
 	},
@@ -660,12 +660,12 @@
 		"soundmark": "/wɛn/"
 	},
 	{
-		"chinese": "当她（过去）是年轻的时候",
+		"chinese": "当她（过去）年轻的时候",
 		"english": "when she was young",
 		"soundmark": "/wɛn/ /ʃi/ /wəz/ /jʌŋ/"
 	},
 	{
-		"chinese": "她（过去）想要改变世界当她（过去）是年轻的时候",
+		"chinese": "她（过去）想要改变世界当她（过去）年轻的时候",
 		"english": "she wanted to change the world when she was young",
 		"soundmark": "/ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
 	},
@@ -675,12 +675,12 @@
 		"soundmark": "/ʃi/ /told/ /mi/"
 	},
 	{
-		"chinese": "她（过去）告诉我她（过去）想要改变世界当她（过去）是年轻的时候",
+		"chinese": "她（过去）告诉我她（过去）想要改变世界当她（过去）年轻的时候",
 		"english": "she told me she wanted to change the world when she was young",
 		"soundmark": "/ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
 	},
 	{
-		"chinese": "我上周末和她聊过天而且她告诉我她（想要）改变世界当她（过去）是年轻的时候",
+		"chinese": "我上周末和她聊过天而且她告诉我她（想要）改变世界当她（过去）年轻的时候",
 		"english": "I talked with her last weekend and she told me she wanted to change the world when she was young",
 		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /læst/ /'wikɛnd/ /ənd/ /ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
 	}

--- a/packages/xingrong-courses/data/courses/14.json
+++ b/packages/xingrong-courses/data/courses/14.json
@@ -20,7 +20,7 @@
 		"soundmark": "/aɪ/ /æm/ /jʌŋ/"
 	},
 	{
-		"chinese": "我是不年轻的",
+		"chinese": "我不年轻了",
 		"english": "I am not young",
 		"soundmark": "/aɪ/ /æm/ /nɑt/ /jʌŋ/"
 	},
@@ -30,7 +30,7 @@
 		"soundmark": "/aɪ/ /wəz/ /jʌŋ/"
 	},
 	{
-		"chinese": "我（过去）是不年轻的",
+		"chinese": "我（过去）不年轻了",
 		"english": "I was not young",
 		"soundmark": "/aɪ/ /wəz/ /nɑt/ /jʌŋ/"
 	},
@@ -45,7 +45,7 @@
 		"soundmark": "/hi/ /ɪz/ /jʌŋ/"
 	},
 	{
-		"chinese": "他是不年轻的",
+		"chinese": "他不年轻了",
 		"english": "he is not young",
 		"soundmark": "/hi/ /ɪz/ /nɑt/ /jʌŋ/"
 	},
@@ -55,7 +55,7 @@
 		"soundmark": "/hi/ /wəz/ /jʌŋ/"
 	},
 	{
-		"chinese": "他（过去）是不年轻的",
+		"chinese": "他（过去）不年轻了",
 		"english": "he was not young",
 		"soundmark": "/hi/ /wəz/ /nɑt/ /jʌŋ/"
 	},
@@ -70,7 +70,7 @@
 		"soundmark": "/wi/ /ɚ/ /jʌŋ/"
 	},
 	{
-		"chinese": "我们是不年轻的",
+		"chinese": "我们不年轻了",
 		"english": "we are not young",
 		"soundmark": "/wi/ /ɚ/ /nɑt/ /jʌŋ/"
 	},
@@ -80,7 +80,7 @@
 		"soundmark": "/wi/ /wɚ/ /jʌŋ/"
 	},
 	{
-		"chinese": "我们（过去）是不年轻的",
+		"chinese": "我们（过去）不年轻了",
 		"english": "we were not young",
 		"soundmark": "/wi/ /wɚ/ /nɑt/ /jʌŋ/"
 	},
@@ -95,7 +95,7 @@
 		"soundmark": "/ju/ /ɚ/ /jʌŋ/"
 	},
 	{
-		"chinese": "你是不年轻的",
+		"chinese": "你不年轻了",
 		"english": "you are not young",
 		"soundmark": "/ju/ /ɚ/ /nɑt/ /jʌŋ/"
 	},
@@ -105,7 +105,7 @@
 		"soundmark": "/ju/ /wɚ/ /jʌŋ/"
 	},
 	{
-		"chinese": "你（过去）是不年轻的",
+		"chinese": "你（过去）不年轻了",
 		"english": "you were not young",
 		"soundmark": "/ju/ /wɚ/ /nɑt/ /jʌŋ/"
 	},
@@ -230,7 +230,7 @@
 		"soundmark": "/ʃi/ /et/ /ən/ /'æpl/ /ən/ /'aʊɚ/ /ə'ɡo/"
 	},
 	{
-		"chinese": "她在一小时之前没吃一个苹果",
+		"chinese": "她一个小时前还没吃苹果呢",
 		"english": "she didn't eat an apple an hour ago",
 		"soundmark": "/ʃi/ /dɪdnt/ /it/ /ən/ /'æpl/ /ən/ /'aʊɚ/ /ə'ɡo/"
 	},
@@ -420,7 +420,7 @@
 		"soundmark": "/aɪ/ /lɔst/ /maɪ/ /dʒɑb/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "我在两年前没有失去我的工作",
+		"chinese": "两年前我还没有失去我的工作",
 		"english": "I didn't lose my job two years ago",
 		"soundmark": "/aɪ/ /dɪdnt/ /luz/ /maɪ/ /dʒɑb/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
@@ -475,7 +475,7 @@
 		"soundmark": "/aɪ/ /lɛft/ /hɚ/ /'ɑfɪs/ /ən/ /'aʊɚ/ /ə'ɡo/"
 	},
 	{
-		"chinese": "我在一小时之前没有离开她的办公室",
+		"chinese": "一小时前我还没离开她的办公室",
 		"english": "I didn't leave her office an hour ago",
 		"soundmark": "/aɪ/ /dɪdnt/ /liv/ /hɚ/ /'ɑfɪs/ /ən/ /'aʊɚ/ /ə'ɡo/"
 	},
@@ -605,17 +605,17 @@
 		"soundmark": "/tə/ /baɪ/"
 	},
 	{
-		"chinese": "一个房子",
+		"chinese": "一栋房子",
 		"english": "a house",
 		"soundmark": "/ə/ /haʊs/"
 	},
 	{
-		"chinese": "买一个房子",
+		"chinese": "买一栋房子",
 		"english": "to buy a house",
 		"soundmark": "/tə/ /baɪ/ /ə/ /haʊs/"
 	},
 	{
-		"chinese": "我想要买一个房子",
+		"chinese": "我想要买一栋房子",
 		"english": "I want to buy a house",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /baɪ/ /ə/ /haʊs/"
 	},
@@ -625,7 +625,7 @@
 		"soundmark": "/bɔt/"
 	},
 	{
-		"chinese": "我买了一个房子",
+		"chinese": "我买了一栋房子",
 		"english": "I bought a house",
 		"soundmark": "/aɪ/ /bɔt/ /ə/ /haʊs/"
 	},
@@ -645,22 +645,22 @@
 		"soundmark": "/tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "我在两年之前买了一个房子",
+		"chinese": "我在两年前买了一栋房子",
 		"english": "I bought a house two years ago",
 		"soundmark": "/aɪ/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "我在两年之前没有买一个房子",
+		"chinese": "两年前我还没有买房子",
 		"english": "I didn't buy a house two years ago",
 		"soundmark": "/aɪ/ /dɪdnt/ /baɪ/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "他在两年之前买了一个房子",
+		"chinese": "他两年前买了一栋房子",
 		"english": "he bought a house two years ago",
 		"soundmark": "/hi/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "他在两年之前没有买一个房子",
+		"chinese": "两年前他还没有买房子",
 		"english": "he didn't buy a house two years ago",
 		"soundmark": "/hi/ /dɪdnt/ /baɪ/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
@@ -675,7 +675,7 @@
 		"soundmark": "/ju/ /hæv/ /tə/ /ʌndɚ'stænd/"
 	},
 	{
-		"chinese": "你必须明白我在两年之前买了一个房子",
+		"chinese": "你必须明白我在两年前买了一栋房子",
 		"english": "you have to understand I bought a house two years ago",
 		"soundmark": "/ju/ /hæv/ /tə/ /ʌndɚ'stænd/ /aɪ/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
@@ -800,17 +800,17 @@
 		"soundmark": "/hi/ /told/ /mi/"
 	},
 	{
-		"chinese": "他两年前买了一个房子",
+		"chinese": "他两年前买了一栋房子",
 		"english": "he bought a house two years ago",
 		"soundmark": "/hi/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "他告诉我他两年前买了一个房子",
+		"chinese": "他告诉我他两年前买了一栋房子",
 		"english": "he told me he bought a house two years ago",
 		"soundmark": "/hi/ /told/ /mi/ /hi/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	},
 	{
-		"chinese": "我昨晚打了电话给他而且他告诉我他在两年之前买了一个房子",
+		"chinese": "我昨晚打了电话给他而且他告诉我他两年前买了一栋房子",
 		"english": "I called him last night and he told me he bought a house two years ago",
 		"soundmark": "/aɪ/ /kɔld/ /hɪm/ /læst/ /naɪt/ /ənd/ /hi/ /told/ /mi/ /hi/ /bɔt/ /ə/ /haʊs/ /tu/ /jɪrz/ /ə'ɡo/"
 	}

--- a/packages/xingrong-courses/data/courses/15.json
+++ b/packages/xingrong-courses/data/courses/15.json
@@ -155,7 +155,7 @@
 		"soundmark": "/fɝ/ /'dɪnɚ/"
 	},
 	{
-		"chinese": "我们决定去外面为了晚餐",
+		"chinese": "我们决定出去吃晚餐",
 		"english": "we decide to go out for dinner",
 		"soundmark": "/wi/ /dɪ'saɪd/ /tə/ /ɡo/ /aʊt/ /fɝ/ /'dɪnɚ/"
 	},
@@ -170,7 +170,7 @@
 		"soundmark": "/wi/ /dɪ'saɪdɪd/"
 	},
 	{
-		"chinese": "我们(过去)决定去外面为了晚餐",
+		"chinese": "我们(过去)决定出去吃晚餐",
 		"english": "we decided to go out for dinner",
 		"soundmark": "/wi/ /dɪ'saɪdɪd/ /tə/ /ɡo/ /aʊt/ /fɝ/ /'dɪnɚ/"
 	},
@@ -390,7 +390,7 @@
 		"soundmark": "/aɪ/ /traɪ/ /tə/ /draɪv/ /ðə/ /kɑr/"
 	},
 	{
-		"chinese": "我不尝试开那辆车",
+		"chinese": "我没有尝试开那辆车",
 		"english": "I don't try to drive the car",
 		"soundmark": "/aɪ/ /dont/ /traɪ/ /tə/ /draɪv/ /ðə/ /kɑr/"
 	},

--- a/packages/xingrong-courses/data/courses/17.json
+++ b/packages/xingrong-courses/data/courses/17.json
@@ -240,7 +240,7 @@
 		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
 	},
 	{
-		"chinese": "我想要你完成你的家庭作业在你看电视之前",
+		"chinese": "我想要你在看电视之前先完成你的家庭作业",
 		"english": "I want you to finish your homework before you watch TV",
 		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/ /bɪ'fɔr/ /ju/ /wɔtʃ/ /ˈtiˈvi/"
 	},
@@ -290,7 +290,7 @@
 		"soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/"
 	},
 	{
-		"chinese": "你可以看电视如果你想的话",
+		"chinese": "如果你想的话可以看电视",
 		"english": "you can watch TV if you want",
 		"soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/ /ɪf/ /ju/ /wɑnt/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "这个问题（过去）是非常困难的对我来说",
+		"chinese": "这个问题对我来说（过去）是非常困难的",
 		"english": "the question was very difficult for me",
 		"soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
 	},
@@ -380,7 +380,7 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为这个问题（过去）是非常困难的对我来说",
+		"chinese": "因为这个问题对我来说（过去）是非常困难的",
 		"english": "because the question was very difficult for me",
 		"soundmark": "/bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
 	},
@@ -390,12 +390,12 @@
 		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
 	},
 	{
-		"chinese": "我（过去）拒绝回答这个问题因为这个问题（过去）是非常困难的对我来说",
+		"chinese": "我（过去）拒绝回答这个问题因为这个问题（过去）对我来说是非常困难的",
 		"english": "I refused to answer the question because the question was very difficult for me",
 		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "我（过去）拒绝回答这个问题因为它（过去）是非常困难的对我来说",
+		"chinese": "我（过去）拒绝回答这个问题因为它对我来说（过去）是非常困难的",
 		"english": "I refused to answer the question because it was very difficult for me",
 		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ɪt/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
 	},
@@ -405,7 +405,7 @@
 		"soundmark": "/'dɪfɪkəlt/"
 	},
 	{
-		"chinese": "它是困难的",
+		"chinese": "这是困难的",
 		"english": "it is difficult",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/"
 	},
@@ -425,7 +425,7 @@
 		"soundmark": "/tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
 	},
 	{
-		"chinese": "完成这个工作（它）是困难的",
+		"chinese": "完成这个工作是困难的",
 		"english": "it is difficult to finish the work",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
 	},
@@ -440,7 +440,7 @@
 		"soundmark": "/ɪn/ /ə/ /de/"
 	},
 	{
-		"chinese": "在一天内完成这个工作（它）是困难的",
+		"chinese": "在一天内完成这个工作是困难的",
 		"english": "it is difficult to finish the work in a day",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/ /ɪn/ /ə/ /de/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/'dendʒərəs/"
 	},
 	{
-		"chinese": "它是危险的",
+		"chinese": "这是危险的",
 		"english": "it is dangerous",
 		"soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/"
 	},
@@ -475,7 +475,7 @@
 		"soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /si/"
 	},
 	{
-		"chinese": "在大海里游泳（它）是危险的",
+		"chinese": "在大海里游泳是危险的",
 		"english": "it is dangerous to swim in the sea",
 		"soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
 	},
@@ -490,12 +490,12 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我认为在大海里游泳（它）是危险的",
+		"chinese": "我认为在大海里游泳是危险的",
 		"english": "I think it is dangerous to swim in the sea",
 		"soundmark": "/aɪ/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
 	},
 	{
-		"chinese": "我不认为在大海里游泳（它）是危险的",
+		"chinese": "我不认为在大海里游泳是危险的",
 		"english": "I don't think it is dangerous to swim in the sea",
 		"soundmark": "/aɪ/ /dont/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
 	},
@@ -515,12 +515,12 @@
 		"soundmark": "/bɪ'kɔz/"
 	},
 	{
-		"chinese": "因为它是危险的",
+		"chinese": "因为这是危险的",
 		"english": "because it is dangerous",
 		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
 	},
 	{
-		"chinese": "我拒绝在大海里游泳因为它是危险的",
+		"chinese": "我拒绝在大海里游泳因为这是危险的",
 		"english": "I refuse to swim in the sea because it is dangerous",
 		"soundmark": "/aɪ/ /ri'fjuz/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
 	},
@@ -600,12 +600,12 @@
 		"soundmark": "/fɝ/ /mi/"
 	},
 	{
-		"chinese": "英语是一个大的挑战对我来说",
+		"chinese": "英语对我来说是一个大的挑战",
 		"english": "English is a big challenge for me",
 		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "英语不是一个大的挑战对我来说",
+		"chinese": "英语对我来说不是一个大的挑战",
 		"english": "English is not a big challenge for me",
 		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
 	},
@@ -650,12 +650,12 @@
 		"soundmark": "/nɪr/"
 	},
 	{
-		"chinese": "在不远的将来",
+		"chinese": "在不久的将来",
 		"english": "in the near future",
 		"soundmark": "/ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "我将会在不远的将来掌握英语",
+		"chinese": "我将在不久的将来掌握英语",
 		"english": "I will master English in the near future",
 		"soundmark": "/aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
 	},
@@ -665,7 +665,7 @@
 		"soundmark": "/aɪ/ /no/"
 	},
 	{
-		"chinese": "我知道我将会在不远的将来掌握英语",
+		"chinese": "我知道我将会在不久的将来掌握英语",
 		"english": "I know I will master English in the near future",
 		"soundmark": "/aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
 	},
@@ -675,17 +675,17 @@
 		"soundmark": "/ənd/"
 	},
 	{
-		"chinese": "而且我知道我将会在不远的将来掌握英语",
+		"chinese": "而且我知道我将会在不久的将来掌握英语",
 		"english": "and I know I will master english in the near future",
 		"soundmark": "/ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
 	},
 	{
-		"chinese": "英语不是一个大的挑战对我来说",
+		"chinese": "英语对我来说不是一个大的挑战",
 		"english": "English is not a big challenge for me",
 		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
 	},
 	{
-		"chinese": "英语不是一个大的挑战对我来说而且我知道我将会在不远的将来掌握英语",
+		"chinese": "英语对我来说不是一个大的挑战而且我知道在不久的将来我会掌握英语",
 		"english": "English is not a big challenge for me and I know I will master english in the near future",
 		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/ /ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
 	}

--- a/packages/xingrong-courses/data/courses/18.json
+++ b/packages/xingrong-courses/data/courses/18.json
@@ -55,22 +55,22 @@
 		"soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "我在厨房里（现在）正在吃鸡蛋",
+		"chinese": "我（现在）正在厨房里吃鸡蛋",
 		"english": "I am eating eggs in the kitchen",
 		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
+		"chinese": "我（过去）正在厨房里吃鸡蛋",
 		"english": "I was eating eggs in the kitchen",
 		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "你在厨房里（现在）正在吃鸡蛋",
+		"chinese": "你（现在）正在厨房里吃鸡蛋",
 		"english": "you are eating eggs in the kitchen",
 		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "你在厨房里（过去）正在吃鸡蛋",
+		"chinese": "你（过去）正在厨房里吃鸡蛋",
 		"english": "you were eating eggs in the kitchen",
 		"soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
@@ -80,12 +80,12 @@
 		"soundmark": "/ðe/"
 	},
 	{
-		"chinese": "他们在厨房里（现在）正在吃鸡蛋",
+		"chinese": "他们（现在）正在厨房里吃鸡蛋",
 		"english": "they are eating eggs in the kitchen",
 		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "他们在厨房里（过去）正在吃鸡蛋",
+		"chinese": "他们（过去）正在厨房里吃鸡蛋",
 		"english": "they were eating eggs in the kitchen",
 		"soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
@@ -135,7 +135,7 @@
 		"soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
 	},
 	{
-		"chinese": "他们在花园里（现在）正在喝茶",
+		"chinese": "他们（现在）正在花园里喝茶",
 		"english": "they are drinking tea in the garden",
 		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
 	},
@@ -145,12 +145,12 @@
 		"soundmark": "/tiː/"
 	},
 	{
-		"chinese": "他们在花园里（过去）正在喝茶",
+		"chinese": "他们（过去）正在花园里喝茶",
 		"english": "they were drinking tea in the garden",
 		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
 	},
 	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
+		"chinese": "我（过去）正在厨房里吃鸡蛋",
 		"english": "I was eating eggs in the kitchen",
 		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
@@ -160,7 +160,7 @@
 		"soundmark": "/waɪl/"
 	},
 	{
-		"chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
+		"chinese": "他们（过去）正在花园里喝茶与此同时我（过去）正在厨房里吃鸡蛋",
 		"english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
 		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
@@ -460,17 +460,17 @@
 		"soundmark": "/ˈslipɪŋ/"
 	},
 	{
-		"chinese": "正在在卧室里睡觉",
+		"chinese": "正在卧室里睡觉",
 		"english": "sleeping in the bedroom",
 		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
-		"chinese": "我正在在卧室里睡觉",
+		"chinese": "我正在卧室里睡觉",
 		"english": "I am sleeping in the bedroom",
 		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
-		"chinese": "我（过去）正在在卧室里睡觉",
+		"chinese": "我（过去）正在卧室里睡觉",
 		"english": "I was sleeping in the bedroom",
 		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
@@ -505,12 +505,12 @@
 		"soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
 	},
 	{
-		"chinese": "我（过去）正在在卧室里睡觉",
+		"chinese": "我（过去）正在卧室里睡觉",
 		"english": "I was sleeping in the bedroom",
 		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
-		"chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
+		"chinese": "当她打电话给我的时候我（过去）正在卧室里睡觉",
 		"english": "I was sleeping in the bedroom when she called me",
 		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
 	},
@@ -560,7 +560,7 @@
 		"soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
 	},
 	{
-		"chinese": "她（过去）正在在客厅弹钢琴",
+		"chinese": "她（过去）正在客厅弹钢琴",
 		"english": "she was playing the piano in the living room",
 		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
 	},
@@ -570,12 +570,12 @@
 		"soundmark": "/waɪl/"
 	},
 	{
-		"chinese": "我（过去）正在在卧室里睡觉",
+		"chinese": "我（过去）正在卧室里睡觉",
 		"english": "I was sleeping in the bedroom",
 		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	},
 	{
-		"chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
+		"chinese": "她（过去）正在客厅弹钢琴与此同时我（过去）正在卧室里睡觉",
 		"english": "she was playing the piano in the living room while I was sleeping in the bedroom",
 		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
 	}

--- a/packages/xingrong-courses/data/courses/19.json
+++ b/packages/xingrong-courses/data/courses/19.json
@@ -80,7 +80,7 @@
 		"soundmark": "/læst/ /naɪt/"
 	},
 	{
-		"chinese": "我昨晚正在阅读一本英语书",
+		"chinese": "昨晚我正在阅读一本英语书",
 		"english": "I was reading an English book last night",
 		"soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /læst/ /naɪt/"
 	},
@@ -235,7 +235,7 @@
 		"soundmark": "/bi/ /'rʌnɪŋ/"
 	},
 	{
-		"chinese": "正在在街上跑步",
+		"chinese": "正在街上跑步",
 		"english": "be running in the street",
 		"soundmark": "/bi/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
 	},
@@ -245,7 +245,7 @@
 		"soundmark": "/hi/"
 	},
 	{
-		"chinese": "他（现在）正在在街上跑步",
+		"chinese": "他（现在）正在街上跑步",
 		"english": "he is running in the street",
 		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
 	},
@@ -255,12 +255,12 @@
 		"soundmark": "/æt/ /ðə/ /'momənt/"
 	},
 	{
-		"chinese": "他此刻正在在街上跑步",
+		"chinese": "他此刻正在街上跑步",
 		"english": "he is running in the street at the moment",
 		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /æt/ /ðə/ /'momənt/"
 	},
 	{
-		"chinese": "他（过去）正在在街上跑步",
+		"chinese": "他（过去）正在街上跑步",
 		"english": "he was running in the street",
 		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
 	},
@@ -300,7 +300,7 @@
 		"soundmark": "/bi/ /'swɪmɪŋ/"
 	},
 	{
-		"chinese": "正在在游泳池里游泳",
+		"chinese": "正在游泳池里游泳",
 		"english": "be swimming in the pool",
 		"soundmark": "/bi/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
 	},
@@ -330,7 +330,7 @@
 		"soundmark": "/ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
 	},
 	{
-		"chinese": "他（过去）正在在街上跑步",
+		"chinese": "他（过去）正在街上跑步",
 		"english": "he was running in the street",
 		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
 	},
@@ -340,7 +340,7 @@
 		"soundmark": "/waɪl/"
 	},
 	{
-		"chinese": "他（过去）正在在街上跑步与此同时她（过去）正在游泳池里游泳",
+		"chinese": "他（过去）正在街上跑步与此同时她（过去）正在游泳池里游泳",
 		"english": "he was running in the street while she was swimming in the pool",
 		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /waɪl/ /ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
 	},
@@ -470,7 +470,7 @@
 		"soundmark": "/bi/ /'tɔkɪŋ/"
 	},
 	{
-		"chinese": "正在在手机上说话",
+		"chinese": "正在手机上说话",
 		"english": "be talking on the phone",
 		"soundmark": "/bi/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
 	},

--- a/packages/xingrong-courses/data/courses/20.json
+++ b/packages/xingrong-courses/data/courses/20.json
@@ -110,7 +110,7 @@
 		"soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
 	},
 	{
-		"chinese": "我们(现在)正在在超市购物",
+		"chinese": "我们(现在)正在超市购物",
 		"english": "we are shopping at the supermarket",
 		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
 	},
@@ -120,12 +120,12 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我们现在正在在超市购物",
+		"chinese": "我们现在正在超市购物",
 		"english": "we are shopping at the supermarket now",
 		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /naʊ/"
 	},
 	{
-		"chinese": "我们(过去)正在在超市购物",
+		"chinese": "我们(过去)正在超市购物",
 		"english": "we were shopping at the supermarket",
 		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
 	},
@@ -175,12 +175,12 @@
 		"soundmark": "/wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
 	},
 	{
-		"chinese": "我们(过去)正在在超市购物当你上周日打电话给我的时候",
+		"chinese": "当你上周日打电话给我的时候我们(过去)正在超市购物",
 		"english": "we were shopping at the supermarket when you called me last Sunday",
 		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
 	},
 	{
-		"chinese": "我们上周日正在在超市购物",
+		"chinese": "我们上周日正在超市购物",
 		"english": "we were shopping at the supermarket last Sunday",
 		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /læst/ /ˈsʌnde/"
 	},
@@ -200,7 +200,7 @@
 		"soundmark": "/wɪl/"
 	},
 	{
-		"chinese": "我们将会正在购物",
+		"chinese": "我们将会去购物",
 		"english": "we will be shopping",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/"
 	},
@@ -210,7 +210,7 @@
 		"soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
 	},
 	{
-		"chinese": "我们将会正在在超市购物",
+		"chinese": "我们将会去超市购物",
 		"english": "we will be shopping at the supermarket",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
 	},
@@ -230,7 +230,7 @@
 		"soundmark": "/nɛkst/ /ˈmʌnde/"
 	},
 	{
-		"chinese": "我们将会在下周一正在在超市购物",
+		"chinese": "我们将会在下周一去超市购物",
 		"english": "we will be shopping at the supermarket next Monday",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /nɛkst/ /ˈmʌnde/"
 	},
@@ -275,12 +275,12 @@
 		"soundmark": "/fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
-		"chinese": "我需要为了我的朋友等待",
+		"chinese": "我需要等待我的朋友",
 		"english": "I need to wait for my friend",
 		"soundmark": "/aɪ/ /nid/ /tə/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
-		"chinese": "我为了我的朋友等待",
+		"chinese": "我等待我的朋友",
 		"english": "I wait for my friend",
 		"soundmark": "/aɪ/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -315,7 +315,7 @@
 		"soundmark": "/fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
-		"chinese": "我(现在)正在为了我的朋友等待",
+		"chinese": "我(现在)正在等待我的朋友",
 		"english": "I am waiting for my friend",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -345,7 +345,7 @@
 		"soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
 	},
 	{
-		"chinese": "我在公交车站(现在)正在为了我的朋友等待",
+		"chinese": "我正在公交车站(现在)等待我的朋友",
 		"english": "I am waiting for my friend at the bus stop",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
 	},
@@ -355,12 +355,12 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我现在在公交车站正在为了我的朋友等待",
+		"chinese": "我现在正在公交车站等待我的朋友",
 		"english": "I am waiting for my friend at the bus stop now",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /naʊ/"
 	},
 	{
-		"chinese": "我在公交车站(过去)正在为了我的朋友等待",
+		"chinese": "我在公交车站(过去)等待我的朋友",
 		"english": "I was waiting for my friend at the bus stop",
 		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/'jɛstɚde/"
 	},
 	{
-		"chinese": "我昨天在公交车站正在为了我的朋友等待",
+		"chinese": "我昨天在公交车站等待我的朋友",
 		"english": "I was waiting for my friend at the bus stop yesterday",
 		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /'jɛstɚde/"
 	},
@@ -410,7 +410,7 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
 	},
 	{
-		"chinese": "我在昨天这个时候在公交车站正在为了我的朋友等待",
+		"chinese": "昨天这个时候我正在公交车站等待我的朋友",
 		"english": "I was waiting for my friend at the bus stop at this time yesterday",
 		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
 	},
@@ -445,17 +445,17 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
 	},
 	{
-		"chinese": "我在前天这个时候在公交车站正在为了我的朋友等待",
+		"chinese": "前天这个时候我正在公交车站等待我的朋友",
 		"english": "I was waiting for my friend at the bus stop at this time the day before yesterday",
 		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
 	},
 	{
-		"chinese": "我(过去)正在为了我的朋友等待",
+		"chinese": "我(过去)正在等待我的朋友",
 		"english": "I was waiting for my friend",
 		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
-		"chinese": "我(现在)正在为了我的朋友等待",
+		"chinese": "我(现在)正在等待我的朋友",
 		"english": "I am waiting for my friend",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -465,7 +465,7 @@
 		"soundmark": "/wɪl/"
 	},
 	{
-		"chinese": "我将会正在为了我的朋友等待",
+		"chinese": "我将等待我的朋友",
 		"english": "I will be waiting for my friend",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -490,7 +490,7 @@
 		"soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
 	},
 	{
-		"chinese": "我将会在公交车站正在为了我的朋友等待",
+		"chinese": "我将会在公交车站等待我的朋友",
 		"english": "I will be waiting for my friend at the bus stop",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
 	},
@@ -510,7 +510,7 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我将会在明天这个时候在公交车站正在为了我的朋友等待",
+		"chinese": "明天这个时候我将会在公交车站等待我的朋友",
 		"english": "I will be waiting for my friend at the bus stop at this time tomorrow",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	},
@@ -545,12 +545,12 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我将会在后天这个时候在公交车站正在为了我的朋友等待",
+		"chinese": "后天这个时候我将会在公交车站等待我的朋友",
 		"english": "I will be waiting for my friend at the bus stop at this time the day after tomorrow",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我将会为了我的朋友正在等待",
+		"chinese": "我将会等待我的朋友",
 		"english": "I will be waiting for my friend",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -560,7 +560,7 @@
 		"soundmark": "/hi/"
 	},
 	{
-		"chinese": "他将会为了我的朋友正在等待",
+		"chinese": "他将会等待我的朋友",
 		"english": "he will be waiting for my friend",
 		"soundmark": "/hi/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -570,12 +570,12 @@
 		"soundmark": "/ðe/"
 	},
 	{
-		"chinese": "他们将会为了我的朋友正在等待",
+		"chinese": "他们将会等待我的朋友",
 		"english": "they will be waiting for my friend",
 		"soundmark": "/ðe/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
 	{
-		"chinese": "我(现在)正在为了我的朋友等待",
+		"chinese": "我(现在)正在等待我的朋友",
 		"english": "I am waiting for my friend",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
 	},
@@ -600,7 +600,7 @@
 		"soundmark": "/fɝ/ /ju/"
 	},
 	{
-		"chinese": "我(现在)正在为了你等待",
+		"chinese": "我(现在)正在等你",
 		"english": "I am waiting for you",
 		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /ju/"
 	},
@@ -660,7 +660,7 @@
 		"soundmark": "/wɪl/"
 	},
 	{
-		"chinese": "我将会正在等你问我那个问题",
+		"chinese": "我将会等你问我那个问题",
 		"english": "I will be waiting for you to ask me that question",
 		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
 	}

--- a/packages/xingrong-courses/data/courses/21.json
+++ b/packages/xingrong-courses/data/courses/21.json
@@ -100,12 +100,12 @@
 		"soundmark": "/ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
-		"chinese": "你需要注意这个信息",
+		"chinese": "你需要关注这个信息",
 		"english": "you need to pay attention to this information",
 		"soundmark": "/ju/ /nid/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
-		"chinese": "你注意这个信息",
+		"chinese": "你关注这个信息",
 		"english": "you pay attention to this information",
 		"soundmark": "/ju/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -115,7 +115,7 @@
 		"soundmark": "/dont/"
 	},
 	{
-		"chinese": "你没有注意这个信息",
+		"chinese": "你没有关注这个信息",
 		"english": "you don't pay attention to this information",
 		"soundmark": "/ju/ /dont/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -125,12 +125,12 @@
 		"soundmark": "/ə'tɛnʃən/"
 	},
 	{
-		"chinese": "你(过去)注意这个信息",
+		"chinese": "你(过去)关注这个信息",
 		"english": "you paid attention to this information",
 		"soundmark": "/ju/ /ped/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
-		"chinese": "你(过去)没有注意这个信息",
+		"chinese": "你(过去)没有关注这个信息",
 		"english": "you didn't pay attention to this information",
 		"soundmark": "/ju/ /ˈdɪdnt/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -145,7 +145,7 @@
 		"soundmark": "/ju/ /ʃʊd/"
 	},
 	{
-		"chinese": "你应该注意这个信息",
+		"chinese": "你应该关注这个信息",
 		"english": "you should pay attention to this information",
 		"soundmark": "/ju/ /ʃʊd/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -155,7 +155,7 @@
 		"soundmark": "/ju/ /ʃʊd/ /nɑt/"
 	},
 	{
-		"chinese": "你不应该注意这个信息",
+		"chinese": "你不应该关注这个信息",
 		"english": "you should not pay attention to this information",
 		"soundmark": "/ju/ /ʃʊd/ /nɑt/ /pe/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
-		"chinese": "正在注意这个信息",
+		"chinese": "正在关注这个信息",
 		"english": "be paying attention to this information",
 		"soundmark": "/bi/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -205,7 +205,7 @@
 		"soundmark": "/ju/"
 	},
 	{
-		"chinese": "你(现在)正在注意这个信息",
+		"chinese": "你(现在)正在关注这个信息",
 		"english": "you are paying attention to this information",
 		"soundmark": "/ju/ /ɚ/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -215,7 +215,7 @@
 		"soundmark": "/aɪ/"
 	},
 	{
-		"chinese": "我(现在)正在注意这个信息",
+		"chinese": "我(现在)正在关注这个信息",
 		"english": "I am paying attention to this information",
 		"soundmark": "/aɪ/ /æm/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -225,7 +225,7 @@
 		"soundmark": "/hi/"
 	},
 	{
-		"chinese": "他(现在)正在注意这个信息",
+		"chinese": "他(现在)正在关注这个信息",
 		"english": "he is paying attention to this information",
 		"soundmark": "/hi/ /ɪz/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -235,12 +235,12 @@
 		"soundmark": "/nɑt/"
 	},
 	{
-		"chinese": "他(现在)没有正在注意这个信息",
+		"chinese": "他(现在)没有关注这个信息",
 		"english": "he is not paying attention to this information",
 		"soundmark": "/hi/ /ɪz/ /nɑt/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
 	{
-		"chinese": "他(过去)正在注意这个信息",
+		"chinese": "他(过去)正在关注这个信息",
 		"english": "he was paying attention to this information",
 		"soundmark": "/hi/ /wəz/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -250,7 +250,7 @@
 		"soundmark": "/nɑt/"
 	},
 	{
-		"chinese": "他(过去)没有正在注意这个信息",
+		"chinese": "他(过去)没有关注这个信息",
 		"english": "he was not paying attention to this information",
 		"soundmark": "/hi/ /wəz/ /nɑt/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -270,7 +270,7 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
 	},
 	{
-		"chinese": "他在昨天这个时候没有注意到这个信息",
+		"chinese": "他昨天这个时候没有关注到这个信息",
 		"english": "he was not paying attention to this information at this time yesterday",
 		"soundmark": "/hi/ /wəz/ /nɑt/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/ /ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
 	},
@@ -285,7 +285,7 @@
 		"soundmark": "/bi/ /peɪŋ/ /ə'tɛnʃən/"
 	},
 	{
-		"chinese": "正在注意这个信息",
+		"chinese": "正在关注这个信息",
 		"english": "be paying attention to this information",
 		"soundmark": "/bi/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -300,7 +300,7 @@
 		"soundmark": "/hi/ /wɪl/"
 	},
 	{
-		"chinese": "他将会正在注意这个信息",
+		"chinese": "他将会关注这个信息",
 		"english": "he will be paying attention to this information",
 		"soundmark": "/hi/ /wɪl/ /bi/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/"
 	},
@@ -320,7 +320,7 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	},
 	{
-		"chinese": "他在明天这个时候将会正在注意这个信息",
+		"chinese": "他将在明天这个时候关注这个信息",
 		"english": "he will be paying attention to this information at this time tomorrow",
 		"soundmark": "/hi/ /wɪl/ /bi/ /peɪŋ/ /ə'tɛnʃən/ /tə/ /ðɪs/ /ɪnfɚ'meʃən/ /ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -385,12 +385,12 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "它是非常重要的",
+		"chinese": "这是非常重要的",
 		"english": "it is very important",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "注意所有的细节(它)是非常重要的",
+		"chinese": "注意所有的细节是非常重要的",
 		"english": "it is very important to pay attention to all the details",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /ɪm'pɔrtnt/ /tə/ /pe/ /ə'tɛnʃən/ /tə/ /ɔl/ /ðə/ /ˈditelz/"
 	},
@@ -435,12 +435,12 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "重要的某件事情",
+		"chinese": "一些重要的事情",
 		"english": "something important",
 		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "我想要讨论重要的某件事情",
+		"chinese": "我想要讨论一些重要的事情",
 		"english": "I would like to discuss something important",
 		"soundmark": "/aɪ/ /wʊd/ /laɪk/ /tə/ /dɪ'skʌs/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/wɪð/ /ju/"
 	},
 	{
-		"chinese": "我想要和你一起讨论重要的某件事情",
+		"chinese": "我想要和你一起讨论一些重要的事情",
 		"english": "I would like to discuss something important with you",
 		"soundmark": "/aɪ/ /wʊd/ /laɪk/ /tə/ /dɪ'skʌs/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/ /wɪð/ /ju/"
 	},
@@ -465,7 +465,7 @@
 		"soundmark": "/wi/"
 	},
 	{
-		"chinese": "我们想要讨论重要的某件事情",
+		"chinese": "我们想要讨论一些重要的事情",
 		"english": "we would like to discuss something important",
 		"soundmark": "/wi/ /wʊd/ /laɪk/ /tə/ /dɪ'skʌs/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
 	},
@@ -515,12 +515,12 @@
 		"soundmark": "/ɔl/ /ðə/ /ˈditelz/"
 	},
 	{
-		"chinese": "这个计划的所有的细节",
+		"chinese": "这个计划的所有细节",
 		"english": "all the details of the plan",
 		"soundmark": "/ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
 	{
-		"chinese": "我们可以讨论这个计划的所有的细节",
+		"chinese": "我们可以讨论这个计划的所有细节",
 		"english": "we can discuss all the details of the plan",
 		"soundmark": "/wi/ /kən/ /dɪ'skʌs/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
@@ -530,7 +530,7 @@
 		"soundmark": "/tə'ɡɛðɚ/"
 	},
 	{
-		"chinese": "我们可以一起讨论这个计划的所有的细节",
+		"chinese": "我们可以一起讨论这个计划的所有细节",
 		"english": "we can discuss all the details of the plan together",
 		"soundmark": "/wi/ /kən/ /dɪ'skʌs/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
@@ -540,7 +540,7 @@
 		"soundmark": "/wɪl/"
 	},
 	{
-		"chinese": "我们将会一起讨论这个计划的所有的细节",
+		"chinese": "我们将会一起讨论这个计划的所有细节",
 		"english": "we will discuss all the details of the plan together",
 		"soundmark": "/wi/ /wɪl/ /dɪ'skʌs/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
@@ -560,7 +560,7 @@
 		"soundmark": "/tə'mɔro/ /'mɔrnɪŋ/"
 	},
 	{
-		"chinese": "我们明天早上将会一起讨论这个计划的所有的细节",
+		"chinese": "明天早上我们将会一起讨论这个计划的所有细节",
 		"english": "we will discuss all the details of the plan together tomorrow morning",
 		"soundmark": "/wi/ /wɪl/ /dɪ'skʌs/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/ /tə'mɔro/ /'mɔrnɪŋ/"
 	},
@@ -580,7 +580,7 @@
 		"soundmark": "/bi/ /dɪ'skʌsɪŋ/"
 	},
 	{
-		"chinese": "这个计划的所有的细节",
+		"chinese": "这个计划的所有细节",
 		"english": "all the details of the plan",
 		"soundmark": "/ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
@@ -605,12 +605,12 @@
 		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/"
 	},
 	{
-		"chinese": "这个计划的所有的细节",
+		"chinese": "这个计划的所有细节",
 		"english": "all the details of the plan",
 		"soundmark": "/ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
 	{
-		"chinese": "我们(现在)正在讨论这个计划的所有的细节",
+		"chinese": "我们(现在)正在讨论这个计划的所有细节",
 		"english": "we are discussing all the details of the plan",
 		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/"
 	},
@@ -620,12 +620,12 @@
 		"soundmark": "/tə'ɡɛðɚ/"
 	},
 	{
-		"chinese": "我们(现在)正在一起讨论这个计划的所有的细节",
+		"chinese": "我们(现在)正在一起讨论这个计划的所有细节",
 		"english": "we are discussing all the details of the plan together",
 		"soundmark": "/wi/ /ɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
 	{
-		"chinese": "我们(过去)正在一起讨论这个计划的所有的细节",
+		"chinese": "我们(过去)正在一起讨论这个计划的所有细节",
 		"english": "we were discussing all the details of the plan together",
 		"soundmark": "/wi/ /wɚ/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
@@ -650,7 +650,7 @@
 		"soundmark": "/wi/ /wɪl/"
 	},
 	{
-		"chinese": "我们将会正在一起讨论这个计划的所有的细节",
+		"chinese": "我们将会一起讨论这个计划的所有细节",
 		"english": "we will be discussing all the details of the plan together",
 		"soundmark": "/wi/ /wɪl/ /bi/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/"
 	},
@@ -670,7 +670,7 @@
 		"soundmark": "/ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	},
 	{
-		"chinese": "我们在明天这个时候将会正在一起讨论这个计划的所有的细节",
+		"chinese": "明天这个时候我们将会一起讨论这个计划的所有细节",
 		"english": "we will be discussing all the details of the plan together at this time tomorrow",
 		"soundmark": "/wi/ /wɪl/ /bi/ /dɪ'skʌsɪŋ/ /ɔl/ /ðə/ /ˈditelz/ /əv/ /ðə/ /plæn/ /tə'ɡɛðɚ/ /ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
 	}

--- a/packages/xingrong-courses/data/courses/22.json
+++ b/packages/xingrong-courses/data/courses/22.json
@@ -395,7 +395,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我(现在)正在尝试解决我们现在正在面对的这个麻烦",
+		"chinese": "我(现在)正在尝试解决我们现在面对的这个麻烦",
 		"english": "I am trying to solve the problem we are facing now",
 		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
 	},
 	{
-		"chinese": "我(现在)正在解决我们(现在)正在面对的这个麻烦",
+		"chinese": "我(现在)正在解决我们(现在)面对的这个麻烦",
 		"english": "I am solving the problem we are facing",
 		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
 	},
@@ -460,7 +460,7 @@
 		"soundmark": "/naʊ/"
 	},
 	{
-		"chinese": "我(现在)正在解决我们现在正在面对的这个麻烦",
+		"chinese": "我(现在)正在解决我们现在面对的这个麻烦",
 		"english": "I am solving the problem we are facing now",
 		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
 	},
@@ -495,7 +495,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "是否我们可以一起解决这个麻烦",
+		"chinese": "我们是否可以一起解决这个麻烦",
 		"english": "if we can solve the problem together",
 		"soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
 	},
@@ -505,7 +505,7 @@
 		"soundmark": "/aɪ/ /'wʌndɚ/"
 	},
 	{
-		"chinese": "我疑惑是否我们可以一起解决这个麻烦",
+		"chinese": "我疑惑我们是否可以一起解决这个麻烦",
 		"english": "I wonder if we can solve the problem together",
 		"soundmark": "/aɪ/ /'wʌndɚ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
 	},
@@ -620,12 +620,12 @@
 		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/"
 	},
 	{
-		"chinese": "是否我们可以一起解决这个麻烦",
+		"chinese": "我们是否可以一起解决这个麻烦",
 		"english": "if we can solve the problem together",
 		"soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
 	},
 	{
-		"chinese": "我(过去)正在疑惑是否我们可以一起解决这个麻烦",
+		"chinese": "我(过去)正在疑惑我们是否可以一起解决这个麻烦",
 		"english": "I was wondering if we can solve the problem together",
 		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
 	},

--- a/packages/xingrong-courses/data/courses/23.json
+++ b/packages/xingrong-courses/data/courses/23.json
@@ -315,17 +315,17 @@
 		"soundmark": "/pliz/"
 	},
 	{
-		"chinese": "麻烦一下递给我我的包",
+		"chinese": "请把包递给我",
 		"english": "please hand me my bag",
 		"soundmark": "/pliz/ /hænd/ /mi/ /maɪ/ /bæɡ/"
 	},
 	{
-		"chinese": "麻烦一下递给我一个香蕉",
+		"chinese": "请递给我一个香蕉",
 		"english": "please hand me a banana",
 		"soundmark": "/pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
-		"chinese": "麻烦一下递给我我的手机",
+		"chinese": "请递给我我的手机",
 		"english": "please hand me my phone",
 		"soundmark": "/pliz/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
@@ -385,7 +385,7 @@
 		"soundmark": "/pliz/"
 	},
 	{
-		"chinese": "你可以麻烦一下递给我我的手机吗？",
+		"chinese": "可以请你递给我我的手机吗？",
 		"english": "can you please hand me my phone",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
@@ -400,7 +400,7 @@
 		"soundmark": "/tə/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
-		"chinese": "你可以麻烦一下递给我一个香蕉吗？",
+		"chinese": "可以请你递给我一个香蕉吗？",
 		"english": "can you please hand me a banana",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
@@ -415,12 +415,12 @@
 		"soundmark": "/kʊd/"
 	},
 	{
-		"chinese": "你可以麻烦一下递给我一个香蕉吗？",
+		"chinese": "可以请你递给我一个香蕉吗？",
 		"english": "can you please hand me a banana",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
-		"chinese": "你可以（礼貌版）麻烦一下递给我一个香蕉吗？",
+		"chinese": "可以请你（礼貌版）递给我一个香蕉吗？",
 		"english": "could you please hand me a banana",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
@@ -435,7 +435,7 @@
 		"soundmark": "/tə/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
 	{
-		"chinese": "你可以（礼貌版）麻烦一下递给我我的手机吗？",
+		"chinese": "你可以（礼貌版）递给我我的手机吗？",
 		"english": "could you please hand me my phone",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/tə/ /hænd/ /mi/ /maɪ/ /skul/ /bæɡ/"
 	},
 	{
-		"chinese": "你可以（礼貌版）麻烦一下递给我我的书包吗？",
+		"chinese": "你可以（礼貌版）递给我我的书包吗？",
 		"english": "could you please hand me my school bag",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /skul/ /bæɡ/"
 	},
@@ -470,7 +470,7 @@
 		"soundmark": "/tə/ /hɛlp/ /mi/"
 	},
 	{
-		"chinese": "你可以（礼貌版）麻烦一下帮助我吗？",
+		"chinese": "你可以（礼貌版）帮助我吗？",
 		"english": "could you please help me",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hɛlp/ /mi/"
 	},

--- a/packages/xingrong-courses/data/courses/24.json
+++ b/packages/xingrong-courses/data/courses/24.json
@@ -120,12 +120,12 @@
 		"soundmark": "/ɪn/ /ðə/ /'mɪrɚ/"
 	},
 	{
-		"chinese": "我(过去)正在在镜子里看着我自己",
+		"chinese": "我(过去)正在镜子里看着我自己",
 		"english": "I was looking at myself in the mirror",
 		"soundmark": "/aɪ/ /wəz/ /ˈlʊkɪŋ/ /ət/ /maɪ'sɛlf/ /ɪn/ /ðə/ /'mɪrɚ/"
 	},
 	{
-		"chinese": "我(现在)正在在镜子里看着我自己",
+		"chinese": "我(现在)正在镜子里看着我自己",
 		"english": "I am looking at myself in the mirror",
 		"soundmark": "/aɪ/ /æm/ /ˈlʊkɪŋ/ /ət/ /maɪ'sɛlf/ /ɪn/ /ðə/ /'mɪrɚ/"
 	},
@@ -155,12 +155,12 @@
 		"soundmark": "/ɪn/ /ðə/ /'mɪrɚ/"
 	},
 	{
-		"chinese": "你(现在)正在在镜子里看着你自己",
+		"chinese": "你(现在)正在镜子里看着你自己",
 		"english": "you are looking at yourself in the mirror",
 		"soundmark": "/ju/ /ɚ/ /ˈlʊkɪŋ/ /ət/ /jɔr'sɛlf/ /ɪn/ /ðə/ /'mɪrɚ/"
 	},
 	{
-		"chinese": "你(过去)正在在镜子里看着你自己",
+		"chinese": "你(过去)正在镜子里看着你自己",
 		"english": "you were looking at yourself in the mirror",
 		"soundmark": "/ju/ /wɚ/ /ˈlʊkɪŋ/ /ət/ /jɔr'sɛlf/ /ɪn/ /ðə/ /'mɪrɚ/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/stɪl/"
 	},
 	{
-		"chinese": "他们(现在)仍然正在看着我们",
+		"chinese": "他们(现在)仍然在看着我们",
 		"english": "they are still looking at us",
 		"soundmark": "/ðe/ /ɚ/ /stɪl/ /ˈlʊkɪŋ/ /ət/ /ʌs/"
 	},
@@ -220,7 +220,7 @@
 		"soundmark": "/fɝ/ /ə/ /nu/ /dʒɑb/"
 	},
 	{
-		"chinese": "为了一个新的工作(有意识地)看",
+		"chinese": "去寻找一份新的工作",
 		"english": "to look for a new job",
 		"soundmark": "/tə/ /lʊk/ /fɝ/ /ə/ /nu/ /dʒɑb/"
 	},
@@ -230,7 +230,7 @@
 		"soundmark": "/tə/ /lʊk/ /fɝ/"
 	},
 	{
-		"chinese": "寻找一个新的工作",
+		"chinese": "去寻找一份新的工作",
 		"english": "to look for a new job",
 		"soundmark": "/tə/ /lʊk/ /fɝ/ /ə/ /nu/ /dʒɑb/"
 	},
@@ -285,7 +285,7 @@
 		"soundmark": "/stɪl/"
 	},
 	{
-		"chinese": "我(现在)仍然正在寻找一个新的工作",
+		"chinese": "我(现在)仍然在寻找一个新的工作",
 		"english": "I am still looking for a new job",
 		"soundmark": "/aɪ/ /æm/ /stɪl/ /ˈlʊkɪŋ/ /fɝ/ /ə/ /nu/ /dʒɑb/"
 	},
@@ -340,7 +340,7 @@
 		"soundmark": "/kænt/"
 	},
 	{
-		"chinese": "我不能找到我的钥匙",
+		"chinese": "我找不到我的钥匙",
 		"english": "I can't find my keys",
 		"soundmark": "/aɪ/ /kænt/ /faɪnd/ /maɪ/ /kiz/"
 	},
@@ -350,17 +350,17 @@
 		"soundmark": "/bʌt/"
 	},
 	{
-		"chinese": "但是我不能找到我的钥匙",
+		"chinese": "但是我找不到我的钥匙",
 		"english": "but I can't find my keys",
 		"soundmark": "/bʌt/ /aɪ/ /kænt/ /faɪnd/ /maɪ/ /kiz/"
 	},
 	{
-		"chinese": "但是我(过去)不能找到我的钥匙",
+		"chinese": "但是我(过去)找不到我的钥匙",
 		"english": "but I couldn't find my keys",
 		"soundmark": "/bʌt/ /aɪ/ /kʊdnt/ /faɪnd/ /maɪ/ /kiz/"
 	},
 	{
-		"chinese": "我(过去)正在寻找我的钥匙但是我(过去)不能找到我的钥匙",
+		"chinese": "我(过去)正在寻找我的钥匙但是我(过去)找不到我的钥匙",
 		"english": "I was looking for my keys but I couldn't find my keys",
 		"soundmark": "/aɪ/ /wəz/ /stɪl/ /ˈlʊkɪŋ/ /fɝ/ /maɪ/ /kiz/ /bʌt/ /aɪ/ /kʊdnt/ /faɪnd/ /maɪ/ /kiz/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/ðəm/"
 	},
 	{
-		"chinese": "我(过去)正在寻找我的钥匙但是我(过去)不能找到它们",
+		"chinese": "我(过去)正在寻找我的钥匙但是我(过去)找不到它们",
 		"english": "I was looking for my keys but I couldn't find them",
 		"soundmark": "/aɪ/ /wəz/ /stɪl/ /ˈlʊkɪŋ/ /fɝ/ /maɪ/ /kiz/ /bʌt/ /aɪ/ /kʊdnt/ /faɪnd/ /ðəm/"
 	},

--- a/packages/xingrong-courses/data/courses/25.json
+++ b/packages/xingrong-courses/data/courses/25.json
@@ -60,12 +60,12 @@
 		"soundmark": "/ɑn/ /hɪz/ /'homwɝk/"
 	},
 	{
-		"chinese": "他需要在他的家庭作业上工作",
+		"chinese": "他需要在他的家庭作业上下功夫",
 		"english": "he needs to work on his homework",
 		"soundmark": "/hi/ /nidz/ /tə/ /wɝk/ /ɑn/ /hɪz/ /'homwɝk/"
 	},
 	{
-		"chinese": "他在他的家庭作业上工作",
+		"chinese": "他在他的家庭作业上下功夫",
 		"english": "he works on his homework",
 		"soundmark": "/hi/ /wɝks/ /ɑn/ /hɪz/ /'homwɝk/"
 	},
@@ -95,7 +95,7 @@
 		"soundmark": "/ɑn/ /hɪz/ /'homwɝk/"
 	},
 	{
-		"chinese": "他(现在)正在在他的家庭作业上工作",
+		"chinese": "他(现在)正在他的家庭作业上下功夫",
 		"english": "he is working on his homework",
 		"soundmark": "/hi/ /ɪz/ /'wɝkɪŋ/ /ɑn/ /hɪz/ /'homwɝk/"
 	},
@@ -125,7 +125,7 @@
 		"soundmark": "/ɑn/"
 	},
 	{
-		"chinese": "我(现在)正在在我的家庭作业上工作",
+		"chinese": "我(现在)正在我的家庭作业上下功夫",
 		"english": "I am working on my homework",
 		"soundmark": "/aɪ/ /æm/ /'wɝkɪŋ/ /ɑn/ /maɪ/ /'homwɝk/"
 	},
@@ -135,7 +135,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "我(现在)正在在那件事上工作",
+		"chinese": "我(现在)正在那件事上工作",
 		"english": "I am working on it",
 		"soundmark": "/aɪ/ /æm/ /'wɝkɪŋ/ /ɑn/ /ɪt/"
 	},
@@ -145,7 +145,7 @@
 		"soundmark": "/stɪl/"
 	},
 	{
-		"chinese": "我(现在)仍然正在在那件事上工作",
+		"chinese": "我(现在)仍然在那件事上工作",
 		"english": "I am still working on it",
 		"soundmark": "/aɪ/ /æm/ /stɪl/ /'wɝkɪŋ/ /ɑn/ /ɪt/"
 	},
@@ -155,7 +155,7 @@
 		"soundmark": "/wi/"
 	},
 	{
-		"chinese": "我们(现在)正在在那件事上工作",
+		"chinese": "我们(现在)正在那件事上工作",
 		"english": "we are working on it",
 		"soundmark": "/wi/ /ɚ/ /'wɝkɪŋ/ /ɑn/ /ɪt/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/ə/ /nu/ /ˈprɑdʒɛkt/"
 	},
 	{
-		"chinese": "我们(现在)正在在一个新的项目上工作",
+		"chinese": "我们(现在)正在一个新的项目上工作",
 		"english": "we are working on a new project",
 		"soundmark": "/wi/ /ɚ/ /'wɝkɪŋ/ /ɑn/ /ə/ /nu/ /ˈprɑdʒɛkt/"
 	},
@@ -190,7 +190,7 @@
 		"soundmark": "/bi/ /'wɝkɪŋ/"
 	},
 	{
-		"chinese": "将会正在工作",
+		"chinese": "将会工作",
 		"english": "will be working",
 		"soundmark": "/wɪl/ /bi/ /'wɝkɪŋ/"
 	},
@@ -200,7 +200,7 @@
 		"soundmark": "/ə/ /nu/ /ˈprɑdʒɛkt/"
 	},
 	{
-		"chinese": "我们将会正在在一个新的项目上工作",
+		"chinese": "我们将会在一个新的项目上工作",
 		"english": "we will be working on a new project",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'wɝkɪŋ/ /ɑn/ /ə/ /nu/ /ˈprɑdʒɛkt/"
 	},
@@ -220,7 +220,7 @@
 		"soundmark": "/nɛkst/ /wik/"
 	},
 	{
-		"chinese": "我们下周将会正在在一个新的项目上工作",
+		"chinese": "下周我们将会在一个新的项目上工作",
 		"english": "we will be working on a new project next week",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'wɝkɪŋ/ /ɑn/ /ə/ /nu/ /ˈprɑdʒɛkt/ /nɛkst/ /wik/"
 	},
@@ -230,12 +230,12 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "我们下周将会正在在那件事上工作",
+		"chinese": "我们将在下周开始工作",
 		"english": "we will be working on it next week",
 		"soundmark": "/wi/ /wɪl/ /bi/ /'wɝkɪŋ/ /ɑn/ /ɪt/ /nɛkst/ /wik/"
 	},
 	{
-		"chinese": "我(现在)正在在那件事上工作",
+		"chinese": "我(现在)正在那件事上工作",
 		"english": "I am working on it",
 		"soundmark": "/aɪ/ /æm/ /'wɝkɪŋ/ /ɑn/ /ɪt/"
 	},
@@ -350,7 +350,7 @@
 		"soundmark": "/kænt/"
 	},
 	{
-		"chinese": "我的女儿不能找到她的玩具",
+		"chinese": "我的女儿找不到她的玩具",
 		"english": "my daughter can't find her toy",
 		"soundmark": "/maɪ/ /'dɔtɚ/ /kænt/ /faɪnd/ /hɚ/ /tɔɪ/"
 	},
@@ -360,7 +360,7 @@
 		"soundmark": "/bʌt/"
 	},
 	{
-		"chinese": "但是我的女儿不能找到她的玩具",
+		"chinese": "但是我的女儿找不到她的玩具",
 		"english": "but my daughter can't find her toy",
 		"soundmark": "/bʌt/ /maɪ/ /'dɔtɚ/ /kænt/ /faɪnd/ /hɚ/ /tɔɪ/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/"
 	},
 	{
-		"chinese": "我的女儿(现在)正在寻找她的玩具但是我的女儿不能找到她的玩具",
+		"chinese": "我的女儿(现在)正在寻找她的玩具但是我的女儿找不到她的玩具",
 		"english": "my daughter is looking for her toy but my daughter can't find her toy",
 		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /bʌt/ /maɪ/ /'dɔtɚ/ /kænt/ /faɪnd/ /hɚ/ /tɔɪ/"
 	},
@@ -385,12 +385,12 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "但是她不能找到它",
+		"chinese": "但是她找不到它",
 		"english": "but she can't find it",
 		"soundmark": "/bʌt/ /ʃi/ /kænt/ /faɪnd/ /ɪt/"
 	},
 	{
-		"chinese": "我的女儿(现在)正在寻找她的玩具但是她不能找到它",
+		"chinese": "我的女儿(现在)正在寻找她的玩具但是她找不到它",
 		"english": "my daughter is looking for her toy but she can't find it",
 		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /bʌt/ /ʃi/ /kænt/ /faɪnd/ /ɪt/"
 	},
@@ -400,12 +400,12 @@
 		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/"
 	},
 	{
-		"chinese": "但是她(过去)不能找到它",
+		"chinese": "但是她(过去)找不到它",
 		"english": "but she couldn't find it",
 		"soundmark": "/bʌt/ /ʃi/ /kʊdnt/ /faɪnd/ /ɪt/"
 	},
 	{
-		"chinese": "我的女儿(过去)正在寻找她的玩具但是她(过去)不能找到它",
+		"chinese": "我的女儿(过去)正在寻找她的玩具但是她(过去)找不到它",
 		"english": "my daughter was looking for her toy but she couldn't find it",
 		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈlʊkɪŋ/ /fɝ/ /hɚ/ /tɔɪ/ /bʌt/ /ʃi/ /kʊdnt/ /faɪnd/ /ɪt/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/ɪf/"
 	},
 	{
-		"chinese": "是否你可以听见我",
+		"chinese": "你是否可以听见我",
 		"english": "if you can hear me",
 		"soundmark": "/ɪf/ /ju/ /kæn/ /hɪr/ /mi/"
 	},
@@ -470,7 +470,7 @@
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/"
 	},
 	{
-		"chinese": "我想要知道是否你可以听见我",
+		"chinese": "我想要知道你是否可以听见我",
 		"english": "I want to know if you can hear me",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /no/ /ɪf/ /ju/ /kæn/ /hɪr/ /mi/"
 	},
@@ -660,7 +660,7 @@
 		"soundmark": "/ju/ /kæn/ /hɪr/"
 	},
 	{
-		"chinese": "你可以听见一把吉他",
+		"chinese": "你可以听见吉他声",
 		"english": "you can hear a guitar",
 		"soundmark": "/ju/ /kæn/ /hɪr/ /ə/ /ɡɪ'tɑr/"
 	},
@@ -685,12 +685,12 @@
 		"soundmark": "/ɪn/ /ðə/ /'bækɡraʊnd/"
 	},
 	{
-		"chinese": "你可以听见一把吉他在背景里",
+		"chinese": "你可以听到背景中的吉他声",
 		"english": "you can hear a guitar in the background",
 		"soundmark": "/ju/ /kæn/ /hɪr/ /ə/ /ɡɪ'tɑr/ /ɪn/ /ðə/ /background/ /'bækɡraʊnd/"
 	},
 	{
-		"chinese": "如果你认真地听这段音乐你可以听见一把吉他在背景里",
+		"chinese": "如果你仔细听音乐就能听到背景中的吉他声",
 		"english": "if you listen to the music carefully you can hear a guitar in the background",
 		"soundmark": "/ɪf/ /ju/ /'lɪsn/ /tə/ /ðə/ /'mjuzɪk/ /'kɛrfəli/ /ju/ /kæn/ /hɪr/ /ə/ /ɡɪ'tɑr/ /ɪn/ /ðə/ /'bækɡraʊnd/"
 	},
@@ -745,7 +745,7 @@
 		"soundmark": "/'nʌθɪŋ/"
 	},
 	{
-		"chinese": "你将会听见没有东西",
+		"chinese": "你将会什么也听不见",
 		"english": "you will hear nothing",
 		"soundmark": "/ju/ /wɪl/ /hɪr/ /'nʌθɪŋ/"
 	},
@@ -755,7 +755,7 @@
 		"soundmark": "/ɪf/ /ju/ /dont/ /'lɪsn/ /'kɛrfəli/"
 	},
 	{
-		"chinese": "如果你不认真地听你将会什么都听不到",
+		"chinese": "如果你不认真听就什么也听不到",
 		"english": "if you don't listen carefully you will hear nothing",
 		"soundmark": "/ɪf/ /ju/ /dont/ /'lɪsn/ /'kɛrfəli/ /ju/ /wɪl/ /hɪr/ /'nʌθɪŋ/"
 	}

--- a/packages/xingrong-courses/data/courses/26.json
+++ b/packages/xingrong-courses/data/courses/26.json
@@ -540,7 +540,7 @@
 		"soundmark": "/tə/ /'fɪnɪʃ/"
 	},
 	{
-		"chinese": "完成你的家庭做作业",
+		"chinese": "完成你的家庭作业",
 		"english": "to finish your homework",
 		"soundmark": "/tə/ /'fɪnɪʃ/ /jʊr/ /'homwɝk/"
 	},

--- a/packages/xingrong-courses/data/courses/27.json
+++ b/packages/xingrong-courses/data/courses/27.json
@@ -355,7 +355,7 @@
 		"soundmark": "/aɪ/ /dont/ /no/ /haʊ/ /tə/ /'hændl/ /ðɪs/ /'prɑbləm/"
 	},
 	{
-		"chinese": "我不知道如何一个人处理这个问题",
+		"chinese": "我不知道如何独自处理这个问题",
 		"english": "I don't know how to handle this problem by myself",
 		"soundmark": "/aɪ/ /dont/ /no/ /haʊ/ /tə/ /'hændl/ /ðɪs/ /'prɑbləm/ /baɪ/ /maɪ'sɛlf/"
 	},
@@ -460,7 +460,7 @@
 		"soundmark": "/ðə/ /pə'lis/ /ɚ/ /'hændlɪŋ/ /ðə/ /'prɑbləm/"
 	},
 	{
-		"chinese": "警察(现在)正在处理他们(现在)正在面对的那个问题",
+		"chinese": "警察(现在)正在处理他们(现在)面对的那个问题",
 		"english": "the police are handling the problem they are facing",
 		"soundmark": "/ðə/ /pə'lis/ /ɚ/ /'hændlɪŋ/ /ðə/ /'prɑbləm/ /ðe/ /ɚ/ /'fesɪŋ/"
 	},
@@ -540,7 +540,7 @@
 		"soundmark": "/baɪ/ /maɪ'sɛlf/"
 	},
 	{
-		"chinese": "我不知道如何一个人应对生活的挑战",
+		"chinese": "我不知道如何独自应对生活中的挑战",
 		"english": "I don't know how to handle life's challenges by myself",
 		"soundmark": "/aɪ/ /dont/ /no/ /haʊ/ /tə/ /'hændl/ /laɪfs/ /ˈtʃælɪndʒɪz/ /baɪ/ /maɪ'sɛlf/"
 	},

--- a/packages/xingrong-courses/data/courses/28.json
+++ b/packages/xingrong-courses/data/courses/28.json
@@ -110,7 +110,7 @@
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/"
 	},
 	{
-		"chinese": "我（现在）正在握着一把刀",
+		"chinese": "我（现在）正握着一把刀",
 		"english": "I am holding a knife",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /naɪf/"
 	},
@@ -130,7 +130,7 @@
 		"soundmark": "/ɪn/ /maɪ/ /hænd/"
 	},
 	{
-		"chinese": "我（现在）正在在我的手里握着一把刀",
+		"chinese": "我（现在）手中正握着一把刀",
 		"english": "I am holding a knife in my hand",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /naɪf/ /ɪn/ /maɪ/ /hænd/"
 	},
@@ -150,12 +150,12 @@
 		"soundmark": "/ɪn/ /maɪ/ /raɪt/ /hænd/"
 	},
 	{
-		"chinese": "我（现在）正在握着一把刀",
+		"chinese": "我（现在）正握着一把刀",
 		"english": "I am holding a knife",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /naɪf/"
 	},
 	{
-		"chinese": "我（现在）正在在我的右手里握着一把刀",
+		"chinese": "我（现在）的右手正握着一把刀",
 		"english": "I am holding a knife in my right hand",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /naɪf/ /ɪn/ /maɪ/ /raɪt/ /hænd/"
 	},
@@ -170,7 +170,7 @@
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/"
 	},
 	{
-		"chinese": "我（现在）正在握着一把叉子",
+		"chinese": "我（现在）正握着一把叉子",
 		"english": "I am holding a fork",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /fɔrk/"
 	},
@@ -190,12 +190,12 @@
 		"soundmark": "/ɪn/ /maɪ/ /lɛft/ /hænd/"
 	},
 	{
-		"chinese": "我（现在）正在握着一把叉子",
+		"chinese": "我（现在）正握着一把叉子",
 		"english": "I am holding a fork",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /fɔrk/"
 	},
 	{
-		"chinese": "我（现在）正在在我的左手里握着一把叉子",
+		"chinese": "我（现在）的左手里正握着一把叉子",
 		"english": "I am holding a fork in my left hand",
 		"soundmark": "/aɪ/ /æm/ /'holdɪŋ/ /ə/ /fɔrk/ /ɪn/ /maɪ/ /lɛft/ /hænd/"
 	},
@@ -250,7 +250,7 @@
 		"soundmark": "/kænt/"
 	},
 	{
-		"chinese": "这辆汽车不可以容纳四个人",
+		"chinese": "这辆汽车容纳不下四个人",
 		"english": "this car can't hold four people",
 		"soundmark": "/ðɪs/ /kɑr/ /kænt/ /hold/ /fɔr/ /'pipl/"
 	},
@@ -305,7 +305,7 @@
 		"soundmark": "/kænt/"
 	},
 	{
-		"chinese": "这个房间不可以容纳十个人",
+		"chinese": "这个房间容纳不下十个人",
 		"english": "this room can't hold ten people",
 		"soundmark": "/ðɪs/ /rum/ /kænt/ /hold/ /tɛn/ /'pipl/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/fɝ/ /ʌs/"
 	},
 	{
-		"chinese": "这个房间是足够大的对我们来说",
+		"chinese": "这个房间对我们来说足够大了",
 		"english": "this room is big enough for us",
 		"soundmark": "/ðɪs/ /rum/ /ɪz/ /bɪɡ/ /ɪ'nʌf/ /fɝ/ /ʌs/"
 	},
@@ -595,7 +595,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是不可能的",
+		"chinese": "这是不可能的",
 		"english": "it is impossible",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɑsəbl/"
 	},

--- a/packages/xingrong-courses/data/courses/29.json
+++ b/packages/xingrong-courses/data/courses/29.json
@@ -50,7 +50,7 @@
 		"soundmark": "/wɪð/ /mi/"
 	},
 	{
-		"chinese": "和我一起在晚上去外面",
+		"chinese": "晚上和我一起外出",
 		"english": "to go out at night with me",
 		"soundmark": "/tə/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /mi/"
 	},
@@ -80,7 +80,7 @@
 		"soundmark": "/wɪ'θaʊt/ /mi/"
 	},
 	{
-		"chinese": "不和我一起在晚上去外面",
+		"chinese": "晚上不和我一起外出",
 		"english": "to go out at night without me",
 		"soundmark": "/tə/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪ'θaʊt/ /mi/"
 	},
@@ -115,7 +115,7 @@
 		"soundmark": "/tə/ /ɡo/ /aʊt/ /ət/ /naɪt/"
 	},
 	{
-		"chinese": "和你的父母一起在晚上去外面",
+		"chinese": "晚上和你的父母一起外出",
 		"english": "to go out at night with your parents",
 		"soundmark": "/tə/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/"
 	},
@@ -130,7 +130,7 @@
 		"soundmark": "/ju/ /kæn/"
 	},
 	{
-		"chinese": "你可以和你父母一起在晚上去外面",
+		"chinese": "晚上你可以和你的父母一起外出",
 		"english": "you can go out at night with your parents",
 		"soundmark": "/ju/ /kæn/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/"
 	},
@@ -155,7 +155,7 @@
 		"soundmark": "/wɪ'θaʊt/ /jʊr/ /'pɛrənts/"
 	},
 	{
-		"chinese": "不和你的父母一起在晚上去外面",
+		"chinese": "晚上在没有父母的陪同下外出",
 		"english": "to go out at night without your parents",
 		"soundmark": "/tə/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪ'θaʊt/ /jʊr/ /'pɛrənts/"
 	},
@@ -170,7 +170,7 @@
 		"soundmark": "/ju/ /kænt/"
 	},
 	{
-		"chinese": "你不可以不和你的父母一起在晚上去外面",
+		"chinese": "没有你父母的陪同晚上你不可以外出",
 		"english": "you can't go out at night without your parents",
 		"soundmark": "/ju/ /kænt/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/"
 	},
@@ -220,17 +220,17 @@
 		"soundmark": "/ɪf/ /ju/ /ɚ/ /nɑt/ /ən/ /əˈdʌlt/"
 	},
 	{
-		"chinese": "你不可以不和你的父母一起在晚上去外面",
+		"chinese": "没有你父母的陪同晚上你不可以外出",
 		"english": "you can't go out at night without your parents",
 		"soundmark": "/ju/ /kænt/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/"
 	},
 	{
-		"chinese": "你不可以不和你的父母一起在晚上去外面如果你不是一个成年人",
+		"chinese": "如果你不是成年人没有你父母的陪同晚上你不可以外出",
 		"english": "you can't go out at night without your parents if you are not an adult",
 		"soundmark": "/ju/ /kænt/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/ /ɪf/ /ju/ /ɚ/ /nɑt/ /ən/ /əˈdʌlt/"
 	},
 	{
-		"chinese": "你可以不和你的父母一起在晚上去外面",
+		"chinese": "晚上你可以在没有父母陪同的情况下外出",
 		"english": "you can go out at night without your parents",
 		"soundmark": "/ju/ /kæn/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/"
 	},
@@ -245,7 +245,7 @@
 		"soundmark": "/ɪf/ /ju/ /ɚ/ /ən/ /əˈdʌlt/"
 	},
 	{
-		"chinese": "你可以不和你的父母一起在晚上去外面如果你是一个成年人",
+		"chinese": "如果你是一个成年人晚上你可以在没有父母陪同的情况下外出",
 		"english": "you can go out at night without your parents if you are an adult",
 		"soundmark": "/ju/ /kæn/ /ɡo/ /aʊt/ /ət/ /naɪt/ /wɪð/ /jʊr/ /'pɛrənts/ /ɪf/ /ju/ /ɚ/ /ən/ /əˈdʌlt/"
 	},
@@ -300,12 +300,12 @@
 		"soundmark": "/wɪ'θaʊt/"
 	},
 	{
-		"chinese": "没有一个驾照",
+		"chinese": "没有驾照",
 		"english": "without a driver's license",
 		"soundmark": "/wɪ'θaʊt/ /ə/ /'draɪvɚz/ /'laɪsns/"
 	},
 	{
-		"chinese": "没有一个驾照你不可以开车",
+		"chinese": "没有驾照你不可以开车",
 		"english": "you can't drive without a driver's license",
 		"soundmark": "/ju/ /kænt/ /draɪv/ /wɪ'θaʊt/ /ə/ /'draɪvɚz/ /'laɪsns/"
 	},
@@ -320,7 +320,7 @@
 		"soundmark": "/ʃʊd/ /nɑt/"
 	},
 	{
-		"chinese": "没有一个驾照你不应该开车",
+		"chinese": "没有驾照你不应该开车",
 		"english": "you should not drive without a driver's license",
 		"soundmark": "/ju/ /ʃʊd/ /nɑt/ /draɪv/ /wɪ'θaʊt/ /ə/ /'draɪvɚz/ /'laɪsns/"
 	},
@@ -365,7 +365,7 @@
 		"soundmark": "/ɪ'nʌf/"
 	},
 	{
-		"chinese": "她是足够年龄大的",
+		"chinese": "她是年龄足够大的",
 		"english": "she is old enough",
 		"soundmark": "/ʃi/ /ɪz/ /old/ /ɪ'nʌf/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/tə/ /draɪv/"
 	},
 	{
-		"chinese": "她是年龄大的足够开车",
+		"chinese": "她已经到了开车的年龄",
 		"english": "she is old enough to drive",
 		"soundmark": "/ʃi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /draɪv/"
 	},
@@ -385,7 +385,7 @@
 		"soundmark": "/nɑt/"
 	},
 	{
-		"chinese": "她不是年龄大的足够开车",
+		"chinese": "她还没到开车的年龄",
 		"english": "she is not old enough to drive",
 		"soundmark": "/ʃi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /draɪv/"
 	},
@@ -400,12 +400,12 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我认为她年龄不够开车",
+		"chinese": "我认为她还没到开车的年龄",
 		"english": "I think she is not old enough to drive",
 		"soundmark": "/aɪ/ /θɪŋk/ /ʃi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /draɪv/"
 	},
 	{
-		"chinese": "我不认为她足够年龄开车",
+		"chinese": "我不认为她已经到了开车的年龄",
 		"english": "I don't think she is old enough to drive",
 		"soundmark": "/aɪ/ /dont/ /θɪŋk/ /ʃi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /draɪv/"
 	},
@@ -440,7 +440,7 @@
 		"soundmark": "/tə/ /dɪ'saɪd/"
 	},
 	{
-		"chinese": "为了她自己决定",
+		"chinese": "由她自己决定",
 		"english": "to decide for herself",
 		"soundmark": "/tə/ /dɪ'saɪd/ /fɝ/ /hɝ'sɛlf/"
 	},
@@ -455,22 +455,22 @@
 		"soundmark": "/ɪ'nʌf/"
 	},
 	{
-		"chinese": "她是足够年龄大的",
+		"chinese": "她是年龄足够大的",
 		"english": "she is old enough",
 		"soundmark": "/ʃi/ /ɪz/ /old/ /ɪ'nʌf/"
 	},
 	{
-		"chinese": "她是年龄大的足够决定",
+		"chinese": "她已经到了做决定的年龄",
 		"english": "she is old enough to decide",
 		"soundmark": "/ʃi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /dɪ'saɪd/"
 	},
 	{
-		"chinese": "为了她自己决定",
+		"chinese": "由她自己决定",
 		"english": "to decide for herself",
 		"soundmark": "/tə/ /dɪ'saɪd/ /fɝ/ /hɝ'sɛlf/"
 	},
 	{
-		"chinese": "她是年龄大的足够为了她自己决定",
+		"chinese": "她已经到了足够由自己做决定的年龄",
 		"english": "she is old enough to decide for herself",
 		"soundmark": "/ʃi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /dɪ'saɪd/ /fɝ/ /hɝ'sɛlf/"
 	},
@@ -505,12 +505,12 @@
 		"soundmark": "/hom/"
 	},
 	{
-		"chinese": "去家",
+		"chinese": "回家",
 		"english": "to go home",
 		"soundmark": "/tə/ /ɡo/ /hom/"
 	},
 	{
-		"chinese": "我想要去家",
+		"chinese": "我想要回家",
 		"english": "I want to go home",
 		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ɡo/ /hom/"
 	},
@@ -560,7 +560,7 @@
 		"soundmark": "/ɪ'nʌf/"
 	},
 	{
-		"chinese": "他是足够年龄大的",
+		"chinese": "他是年龄足够大的",
 		"english": "he is old enough",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/"
 	},
@@ -570,7 +570,7 @@
 		"soundmark": "/tə/ /ɡo/ /tə/ /skul/"
 	},
 	{
-		"chinese": "他是年龄大的足够去上学",
+		"chinese": "他已经到了上学的年龄",
 		"english": "he is old enough to go to school",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /ɡo/ /tə/ /skul/"
 	},
@@ -590,7 +590,7 @@
 		"soundmark": "/tə/ /baɪ/ /'ælkəhɔl/"
 	},
 	{
-		"chinese": "他是足够年龄大的",
+		"chinese": "他是年龄足够大的",
 		"english": "he is old enough",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/"
 	},
@@ -600,12 +600,12 @@
 		"soundmark": "/nɑt/"
 	},
 	{
-		"chinese": "他不是足够年龄大的",
+		"chinese": "他的年龄不够大",
 		"english": "he is not old enough",
 		"soundmark": "/hi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/"
 	},
 	{
-		"chinese": "他不是年龄大的足够去买酒",
+		"chinese": "他还不到买酒的年龄",
 		"english": "he is not old enough to buy alcohol",
 		"soundmark": "/hi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /baɪ/ /'ælkəhɔl/"
 	},
@@ -615,22 +615,22 @@
 		"soundmark": "/bʌt/"
 	},
 	{
-		"chinese": "但是他不是年龄大的足够去买酒",
+		"chinese": "但他还没到买酒的年龄",
 		"english": "but he is not old enough to buy alcohol",
 		"soundmark": "/bʌt/ /hi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /baɪ/ /'ælkəhɔl/"
 	},
 	{
-		"chinese": "他是年龄大的足够去上学",
+		"chinese": "他已经到了上学的年龄",
 		"english": "he is old enough to go to school",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /ɡo/ /tə/ /skul/"
 	},
 	{
-		"chinese": "他是年龄大的足够去上学但是他不是年龄大的足够去买酒",
+		"chinese": "他已经到了上学的年龄但是他还没到可以买酒的年龄",
 		"english": "he is old enough to go to school but he is not old enough to buy alcohol",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /ɡo/ /tə/ /skul/ /bʌt/ /hi/ /ɪz/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /baɪ/ /'ælkəhɔl/"
 	},
 	{
-		"chinese": "他是年龄大的足够去上学但是不是年龄大的足够去买酒",
+		"chinese": "他已经到了上学的年龄但是还没到可以买酒的年龄",
 		"english": "he is old enough to go to school but not old enough to buy alcohol",
 		"soundmark": "/hi/ /ɪz/ /old/ /ɪ'nʌf/ /tə/ /ɡo/ /tə/ /skul/ /bʌt/ /nɑt/ /old/ /ɪ'nʌf/ /tə/ /baɪ/ /'ælkəhɔl/"
 	}

--- a/packages/xingrong-courses/data/courses/30.json
+++ b/packages/xingrong-courses/data/courses/30.json
@@ -455,7 +455,7 @@
 		"soundmark": "/wɛn/ /ju/ /ɡɛt/ /ðɛr/"
 	},
 	{
-		"chinese": "不要忘记打电话给我当你到达那里的时候",
+		"chinese": "当你到达那里的时候不要忘记打电话给我",
 		"english": "don't forget to call me when you get there",
 		"soundmark": "/dont/ /fɚ'ɡɛt/ /tə/ /kɔl/ /mi/ /wɛn/ /ju/ /ɡɛt/ /ðɛr/"
 	},

--- a/packages/xingrong-courses/data/courses/32.json
+++ b/packages/xingrong-courses/data/courses/32.json
@@ -190,7 +190,7 @@
 		"soundmark": "/ju/ /hæv/ /tə/ /kip/ /'kwaɪət/"
 	},
 	{
-		"chinese": "你必须保持安静当你（现在）正在钓鱼的时候",
+		"chinese": "当你（现在）正在钓鱼的时候你必须保持安静",
 		"english": "you have to keep quiet when you are fishing",
 		"soundmark": "/ju/ /hæv/ /tə/ /kip/ /'kwaɪət/ /wɛn/ /ju/ /ɚ/ /'fɪʃɪŋ/"
 	},
@@ -270,7 +270,7 @@
 		"soundmark": "/faɪv/ /'mɪnɪts/"
 	},
 	{
-		"chinese": "她不可以保守一个秘密五分钟",
+		"chinese": "她连五分钟的秘密都守不住",
 		"english": "she can't keep a secret for five minutes",
 		"soundmark": "/ʃi/ /kænt/ /kip/ /ə/ /'sikrət/ /fɝ/ /faɪv/ /'mɪnɪts/"
 	},
@@ -285,7 +285,7 @@
 		"soundmark": "/ʃi/ /sɛd/"
 	},
 	{
-		"chinese": "她（过去）说她不可以保守一个秘密五分钟",
+		"chinese": "她（过去）说她连五分钟的秘密都守不住",
 		"english": "she said she can't keep a secret for five minutes",
 		"soundmark": "/ʃi/ /sɛd/ /ʃi/ /kænt/ /kip/ /ə/ /'sikrət/ /fɝ/ /faɪv/ /'mɪnɪts/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是困难的",
+		"chinese": "这是困难的",
 		"english": "it is difficult",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/"
 	},
@@ -415,12 +415,12 @@
 		"soundmark": "/tə/ /kip/ /ə/ /ɡʊd/ /'bæləns/ /bɪ'twin/ /wɝk/ /ənd/ /laɪf/"
 	},
 	{
-		"chinese": "它是困难的",
+		"chinese": "这是困难的",
 		"english": "it is difficult",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/"
 	},
 	{
-		"chinese": "在工作和生活之间保持一个好的平衡（它）是困难的",
+		"chinese": "在工作和生活之间保持一个好的平衡是困难的",
 		"english": "it is difficult to keep a good balance between work and life",
 		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /kip/ /ə/ /ɡʊd/ /'bæləns/ /bɪ'twin/ /wɝk/ /ənd/ /laɪf/"
 	},
@@ -430,7 +430,7 @@
 		"soundmark": "/ˈvɛri/"
 	},
 	{
-		"chinese": "在工作和生活之间保持一个好的平衡（它）是非常困难的",
+		"chinese": "在工作和生活之间保持一个好的平衡是非常困难的",
 		"english": "it is very difficult to keep a good balance between work and life",
 		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'dɪfɪkəlt/ /tə/ /kip/ /ə/ /ɡʊd/ /'bæləns/ /bɪ'twin/ /wɝk/ /ənd/ /laɪf/"
 	},
@@ -465,7 +465,7 @@
 		"soundmark": "/ə'baʊt/ /ɪt/"
 	},
 	{
-		"chinese": "对于那件事保持沉默",
+		"chinese": "对那件事保持沉默",
 		"english": "to keep quiet about it",
 		"soundmark": "/tə/ /kip/ /'kwaɪət/ /ə'baʊt/ /ɪt/"
 	},
@@ -480,7 +480,7 @@
 		"soundmark": "/aɪ/ /told/ /ju/"
 	},
 	{
-		"chinese": "我（过去）告诉你对于那件事保持沉默",
+		"chinese": "我（过去）告诉你要对那件事保持沉默",
 		"english": "I told you to keep quiet about it",
 		"soundmark": "/aɪ/ /told/ /ju/ /tə/ /kip/ /'kwaɪət/ /ə'baʊt/ /ɪt/"
 	},
@@ -510,7 +510,7 @@
 		"soundmark": "/tə/ /kip/ /'kwaɪət/"
 	},
 	{
-		"chinese": "对于我的计划保持沉默",
+		"chinese": "对我的计划保持沉默",
 		"english": "to keep quiet about my plan",
 		"soundmark": "/tə/ /kip/ /'kwaɪət/ /ə'baʊt/ /maɪ/ /plæn/"
 	},
@@ -520,7 +520,7 @@
 		"soundmark": "/aɪ/ /told/ /ju/"
 	},
 	{
-		"chinese": "我（过去）告诉你对于我的计划保持沉默",
+		"chinese": "我（过去）告诉你对我的计划保持沉默",
 		"english": "I told you to keep quiet about my plan",
 		"soundmark": "/aɪ/ /told/ /ju/ /tə/ /kip/ /'kwaɪət/ /ə'baʊt/ /maɪ/ /plæn/"
 	},
@@ -540,7 +540,7 @@
 		"soundmark": "/ju/ /'prɑmɪst/"
 	},
 	{
-		"chinese": "你（过去）承诺对于我的计划保持沉默",
+		"chinese": "你（过去）承诺对我的计划保持沉默",
 		"english": "you promised to keep quiet about my plan",
 		"soundmark": "/ju/ /'prɑmɪst/ /tə/ /kip/ /'kwaɪət/ /ə'baʊt/ /maɪ/ /plæn/"
 	},
@@ -685,7 +685,7 @@
 		"soundmark": "/wɛn/"
 	},
 	{
-		"chinese": "当我（过去）是年轻的时候",
+		"chinese": "当我（过去）年轻的时候",
 		"english": "when I was young",
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /jʌŋ/"
 	},
@@ -695,7 +695,7 @@
 		"soundmark": "/ˈjʌŋɡər/"
 	},
 	{
-		"chinese": "当我是更年轻的时候",
+		"chinese": "当我更年轻的时候",
 		"english": "when I was younger",
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /ˈjʌŋɡər/"
 	},
@@ -760,7 +760,7 @@
 		"soundmark": "/ðæt/"
 	},
 	{
-		"chinese": "那个我将会每天学英语",
+		"chinese": "（那个）我将会每天学英语",
 		"english": "that I will learn English every day",
 		"soundmark": "/ðæt/ /aɪ/ /wɪl/ /lɝn/ /ˈɪŋɡlɪʃ/ /'ɛvri/ /de/"
 	},
@@ -770,7 +770,7 @@
 		"soundmark": "/aɪ/ /med/ /ə/ /'prɑmɪs/ /tə/ /maɪ'sɛlf/ /wɛn/ /aɪ/ /wəz/ /ˈjʌŋɡər/"
 	},
 	{
-		"chinese": "当我年轻一点的时候我对自己做了一个承诺（那个）我将会每天学英语",
+		"chinese": "当我年轻一点的时候我对自己做了一个承诺我将会每天学英语",
 		"english": "I made a promise to myself when I was younger that I will learn English every day",
 		"soundmark": "/aɪ/ /med/ /ə/ /'prɑmɪs/ /tə/ /maɪ'sɛlf/ /wɛn/ /aɪ/ /wəz/ /ˈjʌŋɡər/ /ðæt/ /aɪ/ /wɪl/ /lɝn/ /ˈɪŋɡlɪʃ/ /'ɛvri/ /de/"
 	},
@@ -780,7 +780,7 @@
 		"soundmark": "/aɪ/ /wʊd/ /lɝn/ /ˈɪŋɡlɪʃ/ /'ɛvri/ /de/"
 	},
 	{
-		"chinese": "当我年轻一点的时候我对自己做了一个承诺（那个）我过去将会每天学英语",
+		"chinese": "当我年轻一点的时候我对自己做了一个承诺我将会每天学英语",
 		"english": "I made a promise to myself when I was younger that I would learn English every day",
 		"soundmark": "/aɪ/ /med/ /ə/ /'prɑmɪs/ /tə/ /maɪ'sɛlf/ /wɛn/ /aɪ/ /wəz/ /ˈjʌŋɡər/ /aɪ/ /wʊd/ /lɝn/ /ˈɪŋɡlɪʃ/ /'ɛvri/ /de/"
 	}

--- a/packages/xingrong-courses/data/courses/33.json
+++ b/packages/xingrong-courses/data/courses/33.json
@@ -150,17 +150,17 @@
 		"soundmark": "/tə/ /baɪ/"
 	},
 	{
-		"chinese": "一个房子",
+		"chinese": "一栋房子",
 		"english": "a house",
 		"soundmark": "/ə/ /haʊs/"
 	},
 	{
-		"chinese": "买一个房子",
+		"chinese": "买一栋房子",
 		"english": "to buy a house",
 		"soundmark": "/tə/ /baɪ/ /ə/ /haʊs/"
 	},
 	{
-		"chinese": "存足够的钱买一个房子",
+		"chinese": "存足够的钱买一栋房子",
 		"english": "to save enough money to buy a house",
 		"soundmark": "/tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /tə/ /baɪ/ /ə/ /haʊs/"
 	},
@@ -190,12 +190,12 @@
 		"soundmark": "/fɝ/ /hɪz/ /ˈfæməli/"
 	},
 	{
-		"chinese": "买一个房子",
+		"chinese": "买一栋房子",
 		"english": "to buy a house",
 		"soundmark": "/tə/ /baɪ/ /ə/ /haʊs/"
 	},
 	{
-		"chinese": "为了他的家庭买一个房子",
+		"chinese": "为他的家庭买一栋房子",
 		"english": "to buy a house for his family",
 		"soundmark": "/tə/ /baɪ/ /ə/ /haʊs/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
@@ -205,7 +205,7 @@
 		"soundmark": "/tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/"
 	},
 	{
-		"chinese": "为了他的家庭存足够的钱买一个房子",
+		"chinese": "存足够的钱为他的家庭买一栋房子",
 		"english": "to save enough money to buy a house for his family",
 		"soundmark": "/tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /tə/ /baɪ/ /ə/ /haʊs/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
@@ -235,7 +235,7 @@
 		"soundmark": "/hi/ /ɪz/ /ˈtraɪɪŋ/"
 	},
 	{
-		"chinese": "他（现在）正在尝试为了他的家庭存足够的钱买一个房子",
+		"chinese": "他（现在）正在尝试存足够的钱为他的家庭买一栋房子",
 		"english": "he is trying to save enough money to buy a house for his family",
 		"soundmark": "/hi/ /ɪz/ /ˈtraɪɪŋ/ /tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /tə/ /baɪ/ /ə/ /haʊs/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
@@ -265,7 +265,7 @@
 		"soundmark": "/tə/ /sev/ /ˈmʌni/"
 	},
 	{
-		"chinese": "存钱的一个好的方法",
+		"chinese": "一个存钱的好方法",
 		"english": "a good way to save money",
 		"soundmark": "/ə/ /ɡʊd/ /we/ /tə/ /sev/ /ˈmʌni/"
 	},
@@ -285,12 +285,12 @@
 		"soundmark": "/ðɪs/ /ɪz/"
 	},
 	{
-		"chinese": "这是存钱的一个好的方法",
+		"chinese": "这是一个存钱的好方法",
 		"english": "this is a good way to save money",
 		"soundmark": "/ðɪs/ /ɪz/ /ə/ /ɡʊd/ /we/ /tə/ /sev/ /ˈmʌni/"
 	},
 	{
-		"chinese": "存钱的一个好的方法是这个",
+		"chinese": "存钱的一个好方法是这个",
 		"english": "a good way to save money is this",
 		"soundmark": "/ə/ /ɡʊd/ /we/ /tə/ /sev/ /ˈmʌni/ /ɪz/ /ðɪs/"
 	},
@@ -420,7 +420,7 @@
 		"soundmark": "/tə/ /mek/ /ə/ /plæn/"
 	},
 	{
-		"chinese": "在你做任何事情之前做一个计划",
+		"chinese": "在你做任何事情之前先做一个计划",
 		"english": "to make a plan before you do anything",
 		"soundmark": "/tə/ /mek/ /ə/ /plæn/ /bɪ'fɔr/ /ju/ /du/ /'ɛnɪθɪŋ/"
 	},
@@ -430,7 +430,7 @@
 		"soundmark": "/ðə/ /bɛst/ /we/ /tə/ /sev/ /taɪm/ /ənd/ /ˈmʌni/"
 	},
 	{
-		"chinese": "节省时间和金钱最好的方法是你做任何事情之前做一个计划",
+		"chinese": "节省时间和金钱最好的方法是你做任何事情之前先做一个计划",
 		"english": "the best way to save time and money is to make a plan before you do anything",
 		"soundmark": "/ðə/ /bɛst/ /we/ /tə/ /sev/ /taɪm/ /ənd/ /ˈmʌni/ /ɪz/ /tə/ /mek/ /ə/ /plæn/ /bɪ'fɔr/ /ju/ /du/ /'ɛnɪθɪŋ/"
 	},
@@ -470,7 +470,7 @@
 		"soundmark": "/tə/ /sev/ /'wɔtɚ/"
 	},
 	{
-		"chinese": "节约水的一个好的方法",
+		"chinese": "一个节约水的好方法",
 		"english": "a good way to save water",
 		"soundmark": "/ə/ /ɡʊd/ /we/ /tə/ /sev/ /'wɔtɚ/"
 	},
@@ -480,7 +480,7 @@
 		"soundmark": "/ðɪs/ /ɪz/"
 	},
 	{
-		"chinese": "这是节约水的一个好的方法",
+		"chinese": "这是一个节约水的好方法",
 		"english": "this is a good way to save water",
 		"soundmark": "/ðɪs/ /ɪz/ /ə/ /ɡʊd/ /we/ /tə/ /sev/ /'wɔtɚ/"
 	},
@@ -510,7 +510,7 @@
 		"soundmark": "/ə/ /ɡʊd/ /we/ /tə/ /sev/ /'wɔtɚ/ /ɪz/ /ðɛr/"
 	},
 	{
-		"chinese": "在那里有节约水的一个好方法",
+		"chinese": "这有一个节约水的好方法",
 		"english": "there is a good way to save water",
 		"soundmark": "/ðɛr/ /ɪz/ /ə/ /ɡʊd/ /we/ /tə/ /sev/ /'wɔtɚ/"
 	},
@@ -530,7 +530,7 @@
 		"soundmark": "/ə/ /bʊk/ /ɪz/ /ðɛr/"
 	},
 	{
-		"chinese": "在那里有一本书",
+		"chinese": "这有一本书",
 		"english": "there is a book",
 		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bʊk/"
 	},
@@ -630,7 +630,7 @@
 		"soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
 	{
-		"chinese": "有五个鸡蛋仔厨房里",
+		"chinese": "有五个鸡蛋在厨房里",
 		"english": "there are five eggs in the kitchen",
 		"soundmark": "/ðɛr/ /ɚ/ /faɪv/ /ɛɡz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
 	},
@@ -665,7 +665,7 @@
 		"soundmark": "/'mɛni/ /wez/"
 	},
 	{
-		"chinese": "节约水的许多方法",
+		"chinese": "许多节约水的方法",
 		"english": "many ways to save water",
 		"soundmark": "/'mɛni/ /wez/ /tə/ /sev/ /'wɔtɚ/"
 	},
@@ -675,7 +675,7 @@
 		"soundmark": "/'dɪfrənt/"
 	},
 	{
-		"chinese": "节约水的许多不同的方法",
+		"chinese": "许多不同节约水的方法",
 		"english": "many different ways to save water",
 		"soundmark": "/'mɛni/ /'dɪfrənt/ /wez/ /tə/ /sev/ /'wɔtɚ/"
 	},
@@ -685,7 +685,7 @@
 		"soundmark": "/ðɛr/ /ɚ/"
 	},
 	{
-		"chinese": "存在节约水的许多不同的方法",
+		"chinese": "存在许多不同节约水的方法",
 		"english": "there are many different ways to save water",
 		"soundmark": "/ðɛr/ /ɚ/ /'mɛni/ /'dɪfrənt/ /wez/ /tə/ /sev/ /'wɔtɚ/"
 	}

--- a/packages/xingrong-courses/data/courses/34.json
+++ b/packages/xingrong-courses/data/courses/34.json
@@ -200,7 +200,7 @@
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
 	},
 	{
-		"chinese": "我(过去)没有注意那个当我以前在这里的时候",
+		"chinese": "当我以前在这里的时候我(过去)没有注意那个",
 		"english": "I didn't notice that when I was here before",
 		"soundmark": "/aɪ/ /ˈdɪdnt/ /ˈnotɪs/ /ðæt/ /wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
 	},
@@ -220,7 +220,7 @@
 		"soundmark": "/rɔŋ/"
 	},
 	{
-		"chinese": "错误的某个东西",
+		"chinese": "某些错误的东西",
 		"english": "something wrong",
 		"soundmark": "/'sʌmθɪŋ/ /rɔŋ/"
 	},
@@ -230,7 +230,7 @@
 		"soundmark": "/ðɛr/"
 	},
 	{
-		"chinese": "错误的某个东西在那里",
+		"chinese": "某些错误的东西在那里",
 		"english": "something wrong is there",
 		"soundmark": "/'sʌmθɪŋ/ /rɔŋ/ /ɪz/ /ðɛr/"
 	},
@@ -240,7 +240,7 @@
 		"soundmark": "/ðɛr/ /ɪz/"
 	},
 	{
-		"chinese": "存在错误的某个东西",
+		"chinese": "存在某些错误的东西",
 		"english": "there is something wrong",
 		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/"
 	},
@@ -250,12 +250,12 @@
 		"soundmark": "/hɪr/"
 	},
 	{
-		"chinese": "这里有错误的某个东西",
+		"chinese": "这有某些错误的东西",
 		"english": "there is something wrong here",
 		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
 	},
 	{
-		"chinese": "这里(过去)有错误的某个东西",
+		"chinese": "这里(过去)有某些错误的东西",
 		"english": "there was something wrong here",
 		"soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
 	},
@@ -265,7 +265,7 @@
 		"soundmark": "/aɪ/ /ˈnotɪst/"
 	},
 	{
-		"chinese": "我(过去)注意到这里(过去)有错误的某个东西",
+		"chinese": "我(过去)注意到这里(过去)有某些错误的东西",
 		"english": "I noticed there was something wrong here",
 		"soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
 	},
@@ -275,7 +275,7 @@
 		"soundmark": "/ðæt/"
 	},
 	{
-		"chinese": "我(过去)注意到(那个)这里(过去)有错误的某个东西",
+		"chinese": "我(过去)注意到(那个)这里(过去)有某些错误的东西",
 		"english": "I noticed that there was something wrong here",
 		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
 	},
@@ -290,12 +290,12 @@
 		"soundmark": "/'sʌmθɪŋ/"
 	},
 	{
-		"chinese": "不同的某个东西",
+		"chinese": "一些不同",
 		"english": "something different",
 		"soundmark": "/'sʌmθɪŋ/ /'dɪfrənt/"
 	},
 	{
-		"chinese": "存在不同的某个东西",
+		"chinese": "存在一些不同",
 		"english": "there is something different",
 		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/"
 	},
@@ -305,12 +305,12 @@
 		"soundmark": "/hɪr/"
 	},
 	{
-		"chinese": "这里有不同的某个东西",
+		"chinese": "这里有一些不同",
 		"english": "there is something different here",
 		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
 	},
 	{
-		"chinese": "这里(过去)有不同的某个东西",
+		"chinese": "这里(过去)有一些不同",
 		"english": "there was something different here",
 		"soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
 	},
@@ -320,7 +320,7 @@
 		"soundmark": "/aɪ/ /ˈnotɪst/"
 	},
 	{
-		"chinese": "我(过去)注意到这里(过去)存在不同的某个东西",
+		"chinese": "我(过去)注意到这里(过去)存在一些不同",
 		"english": "I noticed there was something different here",
 		"soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
 	},
@@ -330,7 +330,7 @@
 		"soundmark": "/ðæt/"
 	},
 	{
-		"chinese": "我(过去)注意到(那个)这里(过去)存在不同的某个东西",
+		"chinese": "我(过去)注意到(那个)这里(过去)存在一些不同",
 		"english": "I noticed that there was something different here",
 		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
 	},
@@ -365,7 +365,7 @@
 		"soundmark": "/bɪ'twin/ /ju/ /ənd/ /mi/"
 	},
 	{
-		"chinese": "在你和我之间的不同",
+		"chinese": "你和我之间的不同",
 		"english": "difference between you and me",
 		"soundmark": "/'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
 	},
@@ -380,7 +380,7 @@
 		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/"
 	},
 	{
-		"chinese": "在你和我之间的一个大的不同",
+		"chinese": "你和我之间的一个大的不同",
 		"english": "a big difference between you and me",
 		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
 	},
@@ -390,7 +390,7 @@
 		"soundmark": "/ðɛr/"
 	},
 	{
-		"chinese": "在你和我之间的一个大的不同在那里",
+		"chinese": "你和我之间的一个大的不同在那里",
 		"english": "a big difference between you and me is there",
 		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/ /ɪz/ /ðɛr/"
 	},
@@ -400,7 +400,7 @@
 		"soundmark": "/ðɛr/ /ɪz/"
 	},
 	{
-		"chinese": "存在在你和我之间的一个大的不同",
+		"chinese": "你和我之间存在一个大的不同",
 		"english": "there is a big difference between you and me",
 		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
 	},
@@ -435,7 +435,7 @@
 		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/"
 	},
 	{
-		"chinese": "存在在一个武器和一个工具之间的一个大的不同",
+		"chinese": "在一个武器和一个工具之间存在一个大的不同",
 		"english": "there is a big difference between a weapon and a tool",
 		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
 	},
@@ -575,7 +575,7 @@
 		"soundmark": "/ɪ'nʌf/"
 	},
 	{
-		"chinese": "足够年龄大",
+		"chinese": "年龄足够大",
 		"english": "old enough",
 		"soundmark": "/old/ /ɪ'nʌf/"
 	},
@@ -585,12 +585,12 @@
 		"soundmark": "/ju/ /ɚ/"
 	},
 	{
-		"chinese": "你是足够年龄大的",
+		"chinese": "你是年龄足够大的",
 		"english": "you are old enough",
 		"soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/"
 	},
 	{
-		"chinese": "你是年龄大的足够分辨是非",
+		"chinese": "你年龄足够大了，能分辨是非了",
 		"english": "you are old enough to tell the difference between right and wrong",
 		"soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
 	},

--- a/packages/xingrong-courses/data/courses/35.json
+++ b/packages/xingrong-courses/data/courses/35.json
@@ -70,7 +70,7 @@
 		"soundmark": "/ɪf/ /ju/ /pe/ /kloz/ /ə'tɛnʃən/"
 	},
 	{
-		"chinese": "你将会注意到那个如果你密切关注",
+		"chinese": "如果你密切关注你将会注意到那个",
 		"english": "you will notice that if you pay close attention",
 		"soundmark": "/ju/ /wɪl/ /ˈnotɪs/ /ðæt/ /ɪf/ /ju/ /pe/ /kloz/ /ə'tɛnʃən/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/ɪf/ /ju/ /pe/ /kloz/ /ə'tɛnʃən/"
 	},
 	{
-		"chinese": "你将会注意到（那个）在美式英语和英式英语之间存在很多不同之处如果你密切关注",
+		"chinese": "如果你密切关注你将会注意到（那个）在美式英语和英式英语之间存在很多不同之处",
 		"english": "you will notice that there are many differences between American English and British English if you pay close attention",
 		"soundmark": "/ju/ /wɪl/ /ˈnotɪs/ /ðæt/ /ðɛr/ /ɚ/ /'mɛni/ /'dɪfrənsɪz/ /bɪ'twin/ /ə'mɛrikən/ /ˈɪŋɡlɪʃ/ /ənd/ /'brɪtɪʃ/ /ˈɪŋɡlɪʃ/ /ɪf/ /ju/ /pe/ /kloz/ /ə'tɛnʃən/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/ju/"
 	},
 	{
-		"chinese": "你是不同的",
+		"chinese": "你是与众不同的",
 		"english": "you are different",
 		"soundmark": "/ju/ /ɚ/ /'dɪfrənt/"
 	},
@@ -205,7 +205,7 @@
 		"soundmark": "/tə/ /prɪˈtɛnd/"
 	},
 	{
-		"chinese": "你假装是不同的",
+		"chinese": "你假装是与众不同的",
 		"english": "you pretend to be different",
 		"soundmark": "/ju/ /prɪˈtɛnd/ /tə/ /bi/ /'dɪfrənt/"
 	},
@@ -215,7 +215,7 @@
 		"soundmark": "/nid/"
 	},
 	{
-		"chinese": "你需要假装是不同的",
+		"chinese": "你需要假装是与众不同的",
 		"english": "you need to pretend to be different",
 		"soundmark": "/ju/ /nid/ /tə/ /prɪˈtɛnd/ /tə/ /bi/ /'dɪfrənt/"
 	},
@@ -225,7 +225,7 @@
 		"soundmark": "/dont/"
 	},
 	{
-		"chinese": "你不需要假装是不同的",
+		"chinese": "你不需要假装是与众不同的",
 		"english": "you don't need to pretend to be different",
 		"soundmark": "/ju/ /dont/ /nid/ /tə/ /prɪˈtɛnd/ /tə/ /bi/ /'dɪfrənt/"
 	},
@@ -245,7 +245,7 @@
 		"soundmark": "/aɪ/ /dont/ /wɑnt/"
 	},
 	{
-		"chinese": "我不想假装是不同的",
+		"chinese": "我不想假装是与众不同的",
 		"english": "I don't want to pretend to be different",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /prɪˈtɛnd/ /tə/ /bi/ /'dɪfrənt/"
 	},
@@ -315,7 +315,7 @@
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /prɪˈtɛnd/ /tə/ /bi/ /ðə/ /'pɝsn/"
 	},
 	{
-		"chinese": "我不想假装是她想要我成为的那个人",
+		"chinese": "我不想假装成她想要我成为的那个人",
 		"english": "I don't want to pretend to be the person she wants me to be",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /prɪˈtɛnd/ /tə/ /bi/ /ðə/ /'pɝsn/ /ʃi/ /wɑnts/ /mi/ /tə/ /bi/"
 	},
@@ -385,7 +385,7 @@
 		"soundmark": "/ɪt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
@@ -395,7 +395,7 @@
 		"soundmark": "/mɔr/"
 	},
 	{
-		"chinese": "它是更重要的",
+		"chinese": "这是更重要的",
 		"english": "it is more important",
 		"soundmark": "/ɪt/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/"
 	},
@@ -415,7 +415,7 @@
 		"soundmark": "/ðæn/ /’ɛnɪθɪŋ/"
 	},
 	{
-		"chinese": "它是比任何事情更重要的",
+		"chinese": "这比任何事情都重要",
 		"english": "it is more important than anything",
 		"soundmark": "/ɪt/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /’ɛnɪθɪŋ/"
 	},
@@ -430,7 +430,7 @@
 		"soundmark": "/’ɛnɪθɪŋ/ /ɛls/"
 	},
 	{
-		"chinese": "它是比其他的任何事情更重要的",
+		"chinese": "这比其他任何事情都重要",
 		"english": "it is more important than anything else",
 		"soundmark": "/ɪt/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /’ɛnɪθɪŋ/ /ɛls/"
 	},
@@ -455,7 +455,7 @@
 		"soundmark": "/'nʌθɪŋ/"
 	},
 	{
-		"chinese": "没有东西比家庭是更重要的",
+		"chinese": "没有什么东西比家庭更重要",
 		"english": "nothing is more important than family",
 		"soundmark": "/'nʌθɪŋ/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /ˈfæməli/"
 	},
@@ -485,7 +485,7 @@
 		"soundmark": "/'aʊɚ/ /ˈfrɛndʃɪp/"
 	},
 	{
-		"chinese": "没有东西比我们的友谊是更重要的",
+		"chinese": "没有什么东西比我们的友谊更重要",
 		"english": "nothing is more important than our friendship",
 		"soundmark": "/'nʌθɪŋ/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /'aʊɚ/ /ˈfrɛndʃɪp/"
 	},
@@ -510,7 +510,7 @@
 		"soundmark": "/’ɛnɪθɪŋ/"
 	},
 	{
-		"chinese": "我的家庭比任何事情是更重要的",
+		"chinese": "我的家庭比任何事情都重要",
 		"english": "my family is more important than anything",
 		"soundmark": "/maɪ/ /ˈfæməli/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /’ɛnɪθɪŋ/"
 	},
@@ -520,7 +520,7 @@
 		"soundmark": "/ɛls/"
 	},
 	{
-		"chinese": "我的家庭比其他的任何事情是更重要的",
+		"chinese": "我的家庭比其他任何事情都重要",
 		"english": "my family is more important than anything else",
 		"soundmark": "/maɪ/ /ˈfæməli/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /’ɛnɪθɪŋ/ /ɛls/"
 	},
@@ -550,7 +550,7 @@
 		"soundmark": "/ˈmʌni/"
 	},
 	{
-		"chinese": "一个人的生命比金钱是更重要的",
+		"chinese": "一个人的生命比金钱更重要",
 		"english": "a man's life is more important than money",
 		"soundmark": "/ə/ /mænz/ /laɪf/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /ˈmʌni/"
 	},
@@ -600,7 +600,7 @@
 		"soundmark": "/wɑt/ /ju/ /seɪ/"
 	},
 	{
-		"chinese": "你做的内容比你说的内容是更重要的",
+		"chinese": "你做的比你说的更重要（行胜于言）",
 		"english": "what you do is more important than what you say",
 		"soundmark": "/wɑt/ /ju/ /du/ /ɪz/ /mɔr/ /ɪm'pɔrtnt/ /ðæn/ /wɑt/ /ju/ /seɪ/"
 	}

--- a/packages/xingrong-courses/data/courses/36.json
+++ b/packages/xingrong-courses/data/courses/36.json
@@ -35,7 +35,7 @@
 		"soundmark": "/ˈɪŋɡlɪʃ/"
 	},
 	{
-		"chinese": "中文比英文是更难的",
+		"chinese": "中文比英文更难",
 		"english": "Chinese is more difficult than English",
 		"soundmark": "/tʃaɪˈniz/ /ɪz/ /mɔr/ /'dɪfɪkəlt/ /ðæn/ /ˈɪŋɡlɪʃ/"
 	},
@@ -115,7 +115,7 @@
 		"soundmark": "/ɪn/ /ðə/ /wɝld/"
 	},
 	{
-		"chinese": "这是在世界上最困难的问题",
+		"chinese": "这是世界上最困难的问题",
 		"english": "this is the most difficult problem in the world",
 		"soundmark": "/ðɪs/ /ɪz/ /ðə/ /most/ /'dɪfɪkəlt/ /'prɑbləm/ /ɪn/ /ðə/ /wɝld/"
 	},
@@ -155,7 +155,7 @@
 		"soundmark": "/ɪn/ /ðə/ /wɝld/"
 	},
 	{
-		"chinese": "他是在世界上最危险的人",
+		"chinese": "他是世界上最危险的人",
 		"english": "he is the most dangerous man in the world",
 		"soundmark": "/hi/ /ɪz/ /ðə/ /most/ /ˈdendʒərəs/ /mæn/ /ɪn/ /ðə/ /wɝld/"
 	},
@@ -340,7 +340,7 @@
 		"soundmark": "/ðæn/ /ˈmʌni/"
 	},
 	{
-		"chinese": "时间比金钱是更宝贵的",
+		"chinese": "时间比金钱更宝贵",
 		"english": "time is more valuable than money",
 		"soundmark": "/taɪm/ /ɪz/ /mɔr/ /'væljuəbl/ /ðæn/ /ˈmʌni/"
 	},
@@ -410,7 +410,7 @@
 		"soundmark": "/ðæn/ /ə/ /juzd/ /kɑr/"
 	},
 	{
-		"chinese": "一辆新车比一辆旧车是更贵的",
+		"chinese": "一辆新车比一辆旧车更贵",
 		"english": "a new car is more expensive than a used car",
 		"soundmark": "/ə/ /nu/ /kɑr/ /ɪz/ /mɔr/ /ɪk'spɛnsɪv/ /ðæn/ /ə/ /juzd/ /kɑr/"
 	},
@@ -670,7 +670,7 @@
 		"soundmark": "/wɛn/ /ju/ /smaɪl/"
 	},
 	{
-		"chinese": "你看起来是更漂亮的当你笑的时候",
+		"chinese": "当你笑的时候你看起来是更漂亮的",
 		"english": "you look more beautiful when you smile",
 		"soundmark": "/ju/ /lʊk/ /mɔr/ /'bjʊtəfəl/ /wɛn/ /ju/ /smaɪl/"
 	},
@@ -680,7 +680,7 @@
 		"soundmark": "/bʌt/"
 	},
 	{
-		"chinese": "但是你看起来是更漂亮的当你笑的时候",
+		"chinese": "但是当你笑的时候你看起来是更漂亮的",
 		"english": "but you look more beautiful when you smile",
 		"soundmark": "/bʌt/ /ju/ /lʊk/ /mɔr/ /'bjʊtəfəl/ /wɛn/ /ju/ /smaɪl/"
 	},

--- a/packages/xingrong-courses/data/courses/37.json
+++ b/packages/xingrong-courses/data/courses/37.json
@@ -30,7 +30,7 @@
 		"soundmark": "/ðæn/ /mi/"
 	},
 	{
-		"chinese": "他是比我更有名的",
+		"chinese": "他比我更有名",
 		"english": "he is more famous than me",
 		"soundmark": "/hi/ /ɪz/ /mɔr/ /'feməs/ /ðæn/ /mi/"
 	},
@@ -45,7 +45,7 @@
 		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/"
 	},
 	{
-		"chinese": "没有人比迈克尔杰克逊是更有名的",
+		"chinese": "没有人比迈克尔杰克逊更有名",
 		"english": "nobody is more famous than Michael Jackson",
 		"soundmark": "/ˈnobɑdi/ /ɪz/ /mɔr/ /'feməs/ /ðæn/ /ˈmaɪkəl/ /ˈdʒæksən/"
 	},
@@ -90,12 +90,12 @@
 		"soundmark": "/ɪn/ /ðə/ /wɝld/"
 	},
 	{
-		"chinese": "迈克尔杰克逊是在世界上最有名的歌手",
+		"chinese": "迈克尔杰克逊是世界上最有名的歌手",
 		"english": "Michael Jackson is the most famous singer in the world",
 		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/ /ɪz/ /ðə/ /most/ /'feməs/ /'sɪŋɚ/ /ɪn/ /ðə/ /wɝld/"
 	},
 	{
-		"chinese": "迈克尔杰克逊（过去）是在世界上最有名的歌手",
+		"chinese": "迈克尔杰克逊（过去）是世界上最有名的歌手",
 		"english": "Michael Jackson was the most famous singer in the world",
 		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/ /wəz/ /ðə/ /most/ /'feməs/ /'sɪŋɚ/ /ɪn/ /ðə/ /wɝld/"
 	},
@@ -130,7 +130,7 @@
 		"soundmark": "/wʌn/ /əv/ /ðə/ /most/ /'feməs/ /'sɪŋɚz/"
 	},
 	{
-		"chinese": "迈克尔杰克逊（过去）是在世界上最有名的歌手之一",
+		"chinese": "迈克尔杰克逊（过去）是世界上最有名的歌手之一",
 		"english": "Michael Jackson was one of the most famous singers in the world",
 		"soundmark": "/ˈmaɪkəl/ /ˈdʒæksən/ /wəz/ /wʌn/ /əv/ /ðə/ /most/ /'feməs/ /'sɪŋɚz/ /ɪn/ /ðə/ /wɝld/"
 	},
@@ -380,7 +380,7 @@
 		"soundmark": "/maɪ/ /ˈɪŋɡlɪʃ/"
 	},
 	{
-		"chinese": "你的中文比我的英文是更好的",
+		"chinese": "你的中文比我的英文更好",
 		"english": "Your Chinese is better than my English",
 		"soundmark": "/jʊr/ /tʃaɪˈniz/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /maɪ/ /ˈɪŋɡlɪʃ/"
 	},
@@ -410,7 +410,7 @@
 		"soundmark": "/ðæn/"
 	},
 	{
-		"chinese": "完成比完美是更好的",
+		"chinese": "完成比完美更好",
 		"english": "done is better than perfect",
 		"soundmark": "/dʌn/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'pɝfɪkt/"
 	},
@@ -425,7 +425,7 @@
 		"soundmark": "/'wɪntɚ/"
 	},
 	{
-		"chinese": "夏天比冬天是更好的",
+		"chinese": "夏天比冬天更好",
 		"english": "summer is better than winter",
 		"soundmark": "/'sʌmɚ/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'wɪntɚ/"
 	},
@@ -435,7 +435,7 @@
 		"soundmark": "/aɪ/ /θɪŋk/"
 	},
 	{
-		"chinese": "我认为夏天比冬天是更好的",
+		"chinese": "我认为夏天比冬天更好",
 		"english": "I think summer is better than winter",
 		"soundmark": "/aɪ/ /θɪŋk/ /'sʌmɚ/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'wɪntɚ/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/'nʌθɪŋ/"
 	},
 	{
-		"chinese": "某个东西比没有东西是更好的",
+		"chinese": "有某些东西比没有东西更好",
 		"english": "something is better than nothing",
 		"soundmark": "/'sʌmθɪŋ/ /ɪz/ /ˈbɛtɚ/ /ðæn/ /'nʌθɪŋ/"
 	},
@@ -530,7 +530,7 @@
 		"soundmark": "/maɪ/"
 	},
 	{
-		"chinese": "我的最好的朋友",
+		"chinese": "我最好的朋友",
 		"english": "my best friend",
 		"soundmark": "/maɪ/ /bɛst/ /frend/"
 	},

--- a/packages/xingrong-courses/data/courses/38.json
+++ b/packages/xingrong-courses/data/courses/38.json
@@ -110,7 +110,7 @@
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /ɪn/ /haɪ/ /skul/"
 	},
 	{
-		"chinese": "我过去常常打篮球当我在高中的时候",
+		"chinese": "当我在高中的时候我常常打篮球",
 		"english": "I used to play basketball when I was in high school",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /ple/ /'bæskɪtbɔl/ /ɪn/ /haɪ/ /skul/ /wɛn/ /aɪ/ /wəz/ /ɪn/ /haɪ/ /skul/"
 	},
@@ -160,12 +160,12 @@
 		"soundmark": "/wɛn/"
 	},
 	{
-		"chinese": "当我(过去)是年轻的时候",
+		"chinese": "当我(过去)年轻的时候",
 		"english": "when I was young",
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /jʌŋ/"
 	},
 	{
-		"chinese": "我过去常常下象棋当我(过去)是年轻的时候",
+		"chinese": "当我(过去)年轻的时候我常常下象棋",
 		"english": "I used to play chess when I was young",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /ple/ /tʃɛs/ /wɛn/ /aɪ/ /wəz/ /jʌŋ/"
 	},
@@ -210,7 +210,7 @@
 		"soundmark": "/'ɛvri/ /'mɔrnɪŋ/"
 	},
 	{
-		"chinese": "我过去每天早上都会看卡通片",
+		"chinese": "我过去常常每天早上都会看卡通片",
 		"english": "I used to watch cartoons every morning",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /wɑtʃ/ /kɑrˈtunz/ /'ɛvri/ /'mɔrnɪŋ/"
 	},
@@ -235,7 +235,7 @@
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /ə/ /kɪd/"
 	},
 	{
-		"chinese": "我过去每天早上都会看卡通片当我(过去)是一个孩子的时候",
+		"chinese": "当我(过去)是一个孩子的时候我常常每天早上都会看卡通片",
 		"english": "I used to watch cartoons every morning when I was a kid",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /wɑtʃ/ /kɑrˈtunz/ /'ɛvri/ /'mɔrnɪŋ/ /wɛn/ /aɪ/ /wəz/ /ə/ /kɪd/"
 	},
@@ -280,7 +280,7 @@
 		"soundmark": "/'ɛvri/ /'mɔrnɪŋ/"
 	},
 	{
-		"chinese": "我过去每天早上喝咖啡",
+		"chinese": "我过去常常每天早上喝咖啡",
 		"english": "I used to drink coffee every morning",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /drɪŋk/ /'kɔfi/ /'ɛvri/ /'mɔrnɪŋ/"
 	},
@@ -330,12 +330,12 @@
 		"soundmark": "/bʌt/ /naʊ/ /aɪ/ /prɪˈfɝ/ /ti/"
 	},
 	{
-		"chinese": "我过去每天早上喝咖啡",
+		"chinese": "我过去常常每天早上喝咖啡",
 		"english": "I used to drink coffee every morning",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /drɪŋk/ /'kɔfi/ /'ɛvri/ /'mɔrnɪŋ/"
 	},
 	{
-		"chinese": "我过去每天早上喝咖啡但是现在我更喜欢茶",
+		"chinese": "我过去常常每天早上喝咖啡但是现在我更喜欢茶",
 		"english": "I used to drink coffee every morning but now I prefer tea",
 		"soundmark": "/aɪ/ /juzd/ /tə/ /drɪŋk/ /'kɔfi/ /'ɛvri/ /'mɔrnɪŋ/ /bʌt/ /naʊ/ /aɪ/ /prɪˈfɝ/ /ti/"
 	},
@@ -635,7 +635,7 @@
 		"soundmark": "/nɑt/ /ɛniˈmɔr/"
 	},
 	{
-		"chinese": "她过去爱他但是再也不会了",
+		"chinese": "她曾经爱过他但是再也不会了",
 		"english": "she used to love him but not anymore",
 		"soundmark": "/ʃi/ /juzd/ /tə/ /lʌv/ /hɪm/ /bʌt/ /nɑt/ /ɛniˈmɔr/"
 	},
@@ -890,12 +890,12 @@
 		"soundmark": "/ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它是重要的",
+		"chinese": "这是重要的",
 		"english": "it is important",
 		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
 	},
 	{
-		"chinese": "它不是重要的",
+		"chinese": "这并不重要",
 		"english": "it is not important",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/"
 	},
@@ -905,7 +905,7 @@
 		"soundmark": "/nɑt/ /ɛniˈmɔr/"
 	},
 	{
-		"chinese": "它再也不是重要的",
+		"chinese": "这已经不重要了",
 		"english": "it is not important anymore",
 		"soundmark": "/ɪt/ /ɪz/ /nɑt/ /ɪm'pɔrtnt/ /ɛniˈmɔr/"
 	},

--- a/packages/xingrong-courses/data/courses/39.json
+++ b/packages/xingrong-courses/data/courses/39.json
@@ -40,7 +40,7 @@
 		"soundmark": "/baɪ/ /hɪm/"
 	},
 	{
-		"chinese": "这辆车通过他被清洗了",
+		"chinese": "这辆车被他清洗了",
 		"english": "the car is washed by him",
 		"soundmark": "/ðə/ /kɑr/ /ɪz/ /wɔʃt/ /baɪ/ /hɪm/"
 	},
@@ -350,7 +350,7 @@
 		"soundmark": "/baɪ/ /mi/"
 	},
 	{
-		"chinese": "这些花将会被我浇水",
+		"chinese": "这些花将会由我来浇水",
 		"english": "the flowers will be watered by me",
 		"soundmark": "/ðə/ /'flaʊɚz/ /wɪl/ /bi/ /'wɔtɚd/ /baɪ/ /mi/"
 	},
@@ -650,12 +650,12 @@
 		"soundmark": "/ðə/ /'dɪnɚ/"
 	},
 	{
-		"chinese": "这顿晚饭是被我妈做的",
+		"chinese": "这顿晚饭是我妈做的",
 		"english": "the dinner is cooked by my mother",
 		"soundmark": "/ðə/ /'dɪnɚ/ /ɪz/ /kʊkt/ /baɪ/ /maɪ/ /'mʌðɚ/"
 	},
 	{
-		"chinese": "这顿晚饭（过去）是被我妈做的",
+		"chinese": "这顿晚饭（过去）是我妈做的",
 		"english": "the dinner was cooked by my mother",
 		"soundmark": "/ðə/ /'dɪnɚ/ /wəz/ /kʊkt/ /baɪ/ /maɪ/ /'mʌðɚ/"
 	},
@@ -795,7 +795,7 @@
 		"soundmark": "/ðə/ /'sikrət/"
 	},
 	{
-		"chinese": "这个秘密将会被保持",
+		"chinese": "这个秘密将会被守住",
 		"english": "the secret will be kept",
 		"soundmark": "/ðə/ /'sikrət/ /wɪl/ /bi/ /kɛpt/"
 	},
@@ -805,7 +805,7 @@
 		"soundmark": "/baɪ/ /hɪm/"
 	},
 	{
-		"chinese": "这个秘密将会被他保持",
+		"chinese": "这个秘密将会被他守住",
 		"english": "the secret will be kept by him",
 		"soundmark": "/ðə/ /'sikrət/ /wɪl/ /bi/ /kɛpt/ /baɪ/ /hɪm/"
 	},
@@ -910,7 +910,7 @@
 		"soundmark": "/tə'mɔro/"
 	},
 	{
-		"chinese": "那场足球比赛明天将会被举行",
+		"chinese": "那场足球比赛将会在明天被举行",
 		"english": "the football match will be held tomorrow",
 		"soundmark": "/ðə/ /'fʊtbɔl/ /mætʃ/ /wɪl/ /bi/ /hɛld/ /tə'mɔro/"
 	}

--- a/packages/xingrong-courses/data/courses/40.json
+++ b/packages/xingrong-courses/data/courses/40.json
@@ -595,7 +595,7 @@
 		"soundmark": "/mɔr/ /'ɔfn/"
 	},
 	{
-		"chinese": "你应该更加经常地练习跳舞",
+		"chinese": "你应该更经常地练习跳舞",
 		"english": "you should practice dancing more often",
 		"soundmark": "/ju/ /ʃʊd/ /ˈpræktɪs/ /'dænsɪŋ/ /mɔr/ /'ɔfn/"
 	},

--- a/packages/xingrong-courses/data/courses/41.json
+++ b/packages/xingrong-courses/data/courses/41.json
@@ -245,7 +245,7 @@
 		"soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
 	},
 	{
-		"chinese": "她总是忘记锁门当她离开的时候",
+		"chinese": "当她离开的时候她总是忘记锁门",
 		"english": "she keeps forgetting to lock the door when she leaves",
 		"soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ʃi/ /livz/"
 	},
@@ -351,7 +351,7 @@
 	},
 	{
 		"chinese": "所有的时间",
-		"english": "all the time",
+		"english": "一直（无时无刻）",
 		"soundmark": "/ɔl/ /ðə/ /taɪm/"
 	},
 	{

--- a/packages/xingrong-courses/data/courses/42.json
+++ b/packages/xingrong-courses/data/courses/42.json
@@ -35,7 +35,7 @@
 		"soundmark": "/hi/ /'fɪnɪʃt/"
 	},
 	{
-		"chinese": "他(过去)完成阅读这本书",
+		"chinese": "他(过去)读完了这本书",
 		"english": "he finished reading the book",
 		"soundmark": "/hi/ /'fɪnɪʃt/ /'ridɪŋ/ /ðə/ /bʊk/"
 	},
@@ -55,7 +55,7 @@
 		"soundmark": "/ɪn/ /wʌn/ /de/"
 	},
 	{
-		"chinese": "他在一天内完成了阅读这本书",
+		"chinese": "他在一天内读完了这本书",
 		"english": "he finished reading the book in one day",
 		"soundmark": "/hi/ /'fɪnɪʃt/ /'ridɪŋ/ /ðə/ /bʊk/ /ɪn/ /wʌn/ /de/"
 	},
@@ -70,7 +70,7 @@
 		"soundmark": "/ɪn/ /wʌn/ /naɪt/"
 	},
 	{
-		"chinese": "他在一个晚上内完成了阅读这本书",
+		"chinese": "他在一个晚上内读完了这本书",
 		"english": "he finished reading the book in one night",
 		"soundmark": "/hi/ /'fɪnɪʃt/ /'ridɪŋ/ /ðə/ /bʊk/ /ɪn/ /wʌn/ /naɪt/"
 	},
@@ -125,7 +125,7 @@
 		"soundmark": "/hi/ /'fɪnɪʃt/"
 	},
 	{
-		"chinese": "他在晚饭之后完成了洗碗",
+		"chinese": "他在晚饭之后洗了那些碗碟",
 		"english": "he finished washing the dishes after dinner",
 		"soundmark": "/hi/ /'fɪnɪʃt/ /'wɑʃɪŋ/ /ðə/ /dɪʃɪz/ /'æftɚ/ /'dɪnɚ/"
 	},
@@ -165,7 +165,7 @@
 		"soundmark": "/ðe/ /'fɪnɪʃt/"
 	},
 	{
-		"chinese": "他们完成了刷墙",
+		"chinese": "他们刷完了墙",
 		"english": "they finished painting the wall",
 		"soundmark": "/ðe/ /'fɪnɪʃt/ /'pentɪŋ/ /ðə/ /wɔl/"
 	},
@@ -190,7 +190,7 @@
 		"soundmark": "/bɪ'fɔr/ /'sʌnsɛt/"
 	},
 	{
-		"chinese": "他们在落日之前完成了刷墙",
+		"chinese": "他们在落日之前刷完了墙",
 		"english": "they finished painting the wall before sunset",
 		"soundmark": "/ðe/ /'fɪnɪʃt/ /'pentɪŋ/ /ðə/ /wɔl/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},
@@ -225,7 +225,7 @@
 		"soundmark": "/ju/ /'fɪnɪʃt/"
 	},
 	{
-		"chinese": "你完成了清理这个房子",
+		"chinese": "你清理了这个房子",
 		"english": "you finished cleaning the house",
 		"soundmark": "/ju/ /'fɪnɪʃt/ /'klinɪŋ/ /ðə/ /haʊs/"
 	},
@@ -240,7 +240,7 @@
 		"soundmark": "/baɪ/ /jɔr'sɛlf/"
 	},
 	{
-		"chinese": "你自己一个人完成了清理这个房子",
+		"chinese": "你自己一个人清理了这个房子",
 		"english": "you finished cleaning the house by yourself",
 		"soundmark": "/ju/ /'fɪnɪʃt/ /'klinɪŋ/ /ðə/ /haʊs/ /baɪ/ /jɔr'sɛlf/"
 	},
@@ -450,7 +450,7 @@
 		"soundmark": "/hi/ /dɪ'naɪd/"
 	},
 	{
-		"chinese": "他(过去)否认假装是有病的",
+		"chinese": "他(过去)否认装病",
 		"english": "he denied pretending to be sick",
 		"soundmark": "/hi/ /dɪ'naɪd/ /prɪ'tɛndɪŋ/ /tə/ /bi/ /sɪk/"
 	},

--- a/packages/xingrong-courses/data/courses/43.json
+++ b/packages/xingrong-courses/data/courses/43.json
@@ -160,7 +160,7 @@
 		"soundmark": "/let/"
 	},
 	{
-		"chinese": "她是迟到的",
+		"chinese": "她迟到了",
 		"english": "she is late",
 		"soundmark": "/ʃi/ /ɪz/ /let/"
 	},
@@ -180,12 +180,12 @@
 		"soundmark": "/fɚ/"
 	},
 	{
-		"chinese": "对于这个会议",
+		"chinese": "对于这个会议（参加会议）",
 		"english": "for the meeting",
 		"soundmark": "/fɚ/ /ðə/ /'mitɪŋ/"
 	},
 	{
-		"chinese": "她是迟到的对于这个会议",
+		"chinese": "她开会迟到了",
 		"english": "she is late for the meeting",
 		"soundmark": "/ʃi/ /ɪz/ /let/ /fɚ/ /ðə/ /'mitɪŋ/ /ədˈmɪtɪd/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/ˈbiɪŋ/"
 	},
 	{
-		"chinese": "她(过去)承认是迟到的对于这个会议",
+		"chinese": "她(过去)承认她开会迟到了",
 		"english": "she admitted being late for the meeting",
 		"soundmark": "/ʃi/ /ədˈmɪtɪd/ /ˈbiɪŋ/ /let/ /fɚ/ /ðə/ /'mitɪŋ/"
 	},
@@ -260,7 +260,7 @@
 		"soundmark": "/dʒʌŋk/"
 	},
 	{
-		"chinese": "垃圾食物",
+		"chinese": "垃圾食品",
 		"english": "junk food",
 		"soundmark": "/dʒʌŋk/ /fud/"
 	},
@@ -270,12 +270,12 @@
 		"soundmark": "/tə/ /it/"
 	},
 	{
-		"chinese": "吃垃圾食物",
+		"chinese": "吃垃圾食品",
 		"english": "to eat junk food",
 		"soundmark": "/tə/ /it/ /dʒʌŋk/ /fud/"
 	},
 	{
-		"chinese": "吃垃圾食物(ing形式)",
+		"chinese": "吃垃圾食品(ing形式)",
 		"english": "eating junk food",
 		"soundmark": "/'itɪŋ/ /dʒʌŋk/ /fud/"
 	},
@@ -290,7 +290,7 @@
 		"soundmark": "/ʃi/ /əˈvɔɪdz/"
 	},
 	{
-		"chinese": "她避免吃垃圾食物",
+		"chinese": "她避免吃垃圾食品",
 		"english": "she avoids eating junk food",
 		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
 	},
@@ -330,12 +330,12 @@
 		"soundmark": "/tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
 	},
 	{
-		"chinese": "她避免吃垃圾食物",
+		"chinese": "她避免吃垃圾食品",
 		"english": "she avoids eating junk food",
 		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
 	},
 	{
-		"chinese": "她避免吃垃圾食物来保持一个健康的生活方式",
+		"chinese": "她通过避免吃垃圾食品来保持一个健康的生活方式",
 		"english": "she avoids eating junk food to maintain a healthy lifestyle",
 		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/ /tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
 	},
@@ -370,7 +370,7 @@
 		"soundmark": "/ʃi/ /əˈvɔɪdɪd/"
 	},
 	{
-		"chinese": "她(过去)避免告诉事实",
+		"chinese": "她(过去)避而不谈事实",
 		"english": "she avoided telling the truth",
 		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
 	},
@@ -410,12 +410,12 @@
 		"soundmark": "/baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
 	},
 	{
-		"chinese": "她(过去)避免告诉事实",
+		"chinese": "她(过去)避而不谈事实",
 		"english": "she avoided telling the truth",
 		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
 	},
 	{
-		"chinese": "她通过向她的父母说谎来(过去)避免告诉事实",
+		"chinese": "她通过向父母撒谎（过去）来避免说出事实",
 		"english": "she avoided telling the truth by lying to her parents",
 		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/ /baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
 	},
@@ -650,7 +650,7 @@
 		"soundmark": "/hi/ /ədˈmɪtɪd/"
 	},
 	{
-		"chinese": "他(过去)承认说一个善意的谎言(ing形式)",
+		"chinese": "他(过去)承认说了一个善意的谎言(ing形式)",
 		"english": "he admitted telling a white lie",
 		"soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
 	},
@@ -700,12 +700,12 @@
 		"soundmark": "/tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
 	},
 	{
-		"chinese": "他(过去)承认说一个善意的谎言",
+		"chinese": "他(过去)承认说了一个善意的谎言",
 		"english": "he admitted telling a white lie",
 		"soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
 	},
 	{
-		"chinese": "他(过去)承认说一个善意的谎言来避免伤害某个人的感情",
+		"chinese": "他(过去)承认说了一个善意的谎言来避免伤害某个人的感情",
 		"english": "he admitted telling a white lie to avoid hurting someone's feelings",
 		"soundmark": "/hi/ /ədˈmɪtɪd/ /tə/ /ədˈmɪt/ /tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
 	}

--- a/packages/xingrong-courses/data/courses/44.json
+++ b/packages/xingrong-courses/data/courses/44.json
@@ -85,7 +85,7 @@
 		"soundmark": "/tə/ /wɝk/"
 	},
 	{
-		"chinese": "从家里工作",
+		"chinese": "在家里工作",
 		"english": "to work from home",
 		"soundmark": "/tə/ /wɝk/ /frʌm/ /hom/"
 	},
@@ -100,12 +100,12 @@
 		"soundmark": "/ɑn/ /ˈfraɪde/"
 	},
 	{
-		"chinese": "在周五居家办公",
+		"chinese": "周五居家办公",
 		"english": "to work from home on Fridays",
 		"soundmark": "/tə/ /wɝk/ /frʌm/ /hom/ /ɑn/ /ˈfraɪdez/"
 	},
 	{
-		"chinese": "在周五居家办公(ing形式)",
+		"chinese": "周五居家办公(ing形式)",
 		"english": "working from home on Fridays",
 		"soundmark": "/ˈwɝkɪŋ/ /frʌm/ /hom/ /ɑn/ /ˈfraɪdez/"
 	},
@@ -125,7 +125,7 @@
 		"soundmark": "/ðə/ /ˈkʌmpəni/ /pɚˈmɪts/"
 	},
 	{
-		"chinese": "公司允许在周五居家办公",
+		"chinese": "公司允许周五居家办公",
 		"english": "the company permits working from home on Fridays",
 		"soundmark": "/ðə/ /ˈkʌmpəni/ /pɚˈmɪts/ /ˈwɝkɪŋ/ /frʌm/ /hom/ /ɑn/ /ˈfraɪdez/"
 	},
@@ -445,7 +445,7 @@
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/ /'draɪvɪŋ/"
 	},
 	{
-		"chinese": "政策允许开车如果你拥有一个有效的执照",
+		"chinese": "如果你拥有一个有效的执照政策允许开车",
 		"english": "the policy permits driving if you have a valid license",
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/ /'draɪvɪŋ/ /ɪf/ /ju/ /hæv/ /ə/ /ˈvælɪd/ /ˈlaɪsns/"
 	},
@@ -525,7 +525,7 @@
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/ /'trævlɪŋ/ /ə'brɔd/"
 	},
 	{
-		"chinese": "政策允许出国旅行如果你拥有一个有效的护照",
+		"chinese": "如果你拥有一个有效的护照政策允许出国旅行",
 		"english": "the policy permits traveling abroad if you have a valid passport",
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/ /'trævlɪŋ/ /ə'brɔd/ /ɪf/ /ju/ /hæv/ /ə/ /ˈvælɪd/ /'pæspɔrt/"
 	},
@@ -650,7 +650,7 @@
 		"soundmark": "/wɪð/"
 	},
 	{
-		"chinese": "和一个有效的执照一起驾驶",
+		"chinese": "持有效驾照驾车",
 		"english": "to drive with a valid license",
 		"soundmark": "/tə/ /draɪv/ /wɪð/ /ə/ /ˈvælɪd/ /ˈlaɪsns/"
 	},

--- a/packages/xingrong-courses/data/courses/45.json
+++ b/packages/xingrong-courses/data/courses/45.json
@@ -125,12 +125,12 @@
 		"soundmark": "/bɪ'fɔr/ /'sʌnsɛt/"
 	},
 	{
-		"chinese": "在日落之前在大海里游泳",
+		"chinese": "日落之前在大海里游泳",
 		"english": "to swim in the sea before sunset",
 		"soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},
 	{
-		"chinese": "在日落之前在大海里游泳(ing形式)",
+		"chinese": "日落之前在大海里游泳(ing形式)",
 		"english": "swimming in the sea before sunset",
 		"soundmark": "/'swɪmɪŋ/ /ɪn/ /ðə/ /si/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},
@@ -150,7 +150,7 @@
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/"
 	},
 	{
-		"chinese": "政策允许在日落之前在大海里游泳",
+		"chinese": "政策允许日落之前在大海里游泳",
 		"english": "the policy permits swimming in the sea before sunset",
 		"soundmark": "/ðə/ /ˈpɑləsi/ /pɚˈmɪts/ /'swɪmɪŋ/ /ɪn/ /ðə/ /si/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},
@@ -190,12 +190,12 @@
 		"soundmark": "/hɪz/ /'fɑðɚ/ /pɚˈmɪts/ /hɪm/"
 	},
 	{
-		"chinese": "在日落之前在大海里游泳",
+		"chinese": "日落之前在大海里游泳",
 		"english": "to swim in the sea before sunset",
 		"soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},
 	{
-		"chinese": "他的父亲允许他在日落之前在大海里游泳",
+		"chinese": "他的父亲允许他日落之前在大海里游泳",
 		"english": "his father permits him to swim in the sea before sunset",
 		"soundmark": "/hɪz/ /'fɑðɚ/ /pɚˈmɪts/ /hɪm/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'fɔr/ /'sʌnsɛt/"
 	},

--- a/packages/xingrong-courses/data/courses/46.json
+++ b/packages/xingrong-courses/data/courses/46.json
@@ -245,12 +245,12 @@
 		"soundmark": "/tə/ /ˈpræktɪs/"
 	},
 	{
-		"chinese": "练习和母语使用者说话",
+		"chinese": "和母语使用者练习口语",
 		"english": "to practice speaking with native speakers",
 		"soundmark": "/tə/ /ˈpræktɪs/ /'spikɪŋ/ /wɪð/ /ˈnetɪv/ /'spikɚz/"
 	},
 	{
-		"chinese": "练习和母语使用者说话(ing形式)",
+		"chinese": "和母语使用者练习口语(ing形式)",
 		"english": "practicing speaking with native speakers",
 		"soundmark": "/ˈpræktɪsɪŋ/ /'spikɪŋ/ /wɪð/ /ˈnetɪv/ /'spikɚz/"
 	},
@@ -260,7 +260,7 @@
 		"soundmark": "/ʃi/ /traɪd/"
 	},
 	{
-		"chinese": "她(过去)尝试练习和母语使用者说话",
+		"chinese": "她(过去)尝试和母语使用者练习口语",
 		"english": "she tried practicing speaking with native speakers",
 		"soundmark": "/ʃi/ /traɪd/ /ˈpræktɪsɪŋ/ /'spikɪŋ/ /wɪð/ /ˈnetɪv/ /'spikɚz/"
 	},

--- a/packages/xingrong-courses/data/courses/48.json
+++ b/packages/xingrong-courses/data/courses/48.json
@@ -295,7 +295,7 @@
 		"soundmark": "/ə/ /lɑt/"
 	},
 	{
-		"chinese": "你(已经)提高了你的英文很多",
+		"chinese": "你(已经)提高了你的英文很多（你的英语水平提高了很多）",
 		"english": "you have improved your English a lot",
 		"soundmark": "/ju/ /hæv/ /ɪmˈpruvd/ /jʊr/ /ˈɪŋɡlɪʃ/ /ə/ /lɑt/"
 	},
@@ -540,7 +540,7 @@
 		"soundmark": "/faɪv/ /jɪrz/"
 	},
 	{
-		"chinese": "我(已经)在这个城市里居住了五年了",
+		"chinese": "我(已经)在这个城市里居住五年了",
 		"english": "I have lived in this city for five years",
 		"soundmark": "/aɪ/ /hæv/ /lɪvd/ /ɪn/ /ðɪs/ /'sɪti/ /fɚ/ /faɪv/ /jɪrz/"
 	},
@@ -590,7 +590,7 @@
 		"soundmark": "/θri/ /jɪrz/"
 	},
 	{
-		"chinese": "我(已经)在那个公司工作了三年了",
+		"chinese": "我(已经)在那个公司工作三年了",
 		"english": "I have worked at that company for three years",
 		"soundmark": "/aɪ/ /hæv/ /wɝkt/ /ət/ /ðæt/ /ˈkʌmpəni/ /fɚ/ /θri/ /jɪrz/"
 	},
@@ -645,7 +645,7 @@
 		"soundmark": "/θri/ /jɪrz/"
 	},
 	{
-		"chinese": "我们(已经)学习了英文三年了",
+		"chinese": "我们(已经)学习英文三年了",
 		"english": "we have studied English for three years",
 		"soundmark": "/wi/ /hæv/ /ˈstʌdid/ /ˈɪŋɡlɪʃ/ /fɚ/ /θri/ /jɪrz/"
 	},

--- a/packages/xingrong-courses/data/courses/49.json
+++ b/packages/xingrong-courses/data/courses/49.json
@@ -360,7 +360,7 @@
 		"soundmark": "/ðe/ /hæv/ /mɛt/"
 	},
 	{
-		"chinese": "他们(已经)见过他们的新邻居",
+		"chinese": "他们(已经)见过了他们的新邻居",
 		"english": "they have met their new neighbors",
 		"soundmark": "/ðe/ /hæv/ /mɛt/ /ðɛr/ /nu/ /ˈnebɚ/"
 	},
@@ -525,7 +525,7 @@
 		"soundmark": "/ði/ /ˈimel/"
 	},
 	{
-		"chinese": "他(已经)收到那个电子邮件",
+		"chinese": "他(已经)收到了那个电子邮件",
 		"english": "he has received the email",
 		"soundmark": "/hi/ /hæz/ /rɪ'sivd/ /ði/ /ˈimel/"
 	},
@@ -705,7 +705,7 @@
 		"soundmark": "/fɝ/ /hɪz/ /ˈfæməli/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树",
 		"english": "he has bought a Christmas tree for his family",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
@@ -730,7 +730,7 @@
 		"soundmark": "/ðə/ /ˈkrɪsməs/ /tri/"
 	},
 	{
-		"chinese": "那棵圣诞树被装饰了的",
+		"chinese": "那棵圣诞树是被装饰了的",
 		"english": "the Christmas tree is decorated",
 		"soundmark": "/ðə/ /ˈkrɪsməs/ /tri/ /ɪz/ /ˈdɛkəretɪd/"
 	},
@@ -740,7 +740,7 @@
 		"soundmark": "/ə/ /ˈdɛkəretɪd/ /ˈkrɪsməs/ /tri/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵装饰好了的圣诞树",
+		"chinese": "他为他的家庭(已经)买了一棵装饰好了的圣诞树",
 		"english": "he has bought a decorated Christmas tree for his family",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈdɛkəretɪd/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
@@ -790,17 +790,17 @@
 		"soundmark": "/bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ðə/ /ˈkrɪsməs/ /tri/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树",
 		"english": "he has bought a Christmas tree for his family",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树但是他(还没有)装饰那棵圣诞树",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树但是他(还没有)装饰那棵圣诞树",
 		"english": "he has bought a Christmas tree for his family but he hasn't decorated the Christmas tree",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/ /bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ðə/ /ˈkrɪsməs/ /tri/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树但是他(还没有)装饰它",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树但是他(还没有)装饰它",
 		"english": "he has bought a Christmas tree for his family but he hasn't decorated it",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/ /bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ɪt/"
 	},
@@ -810,7 +810,7 @@
 		"soundmark": "/jɛt/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树但是迄今为止他(还没有)装饰它",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树但是迄今为止他(还没有)装饰它",
 		"english": "he has bought a Christmas tree for his family but he hasn't decorated it yet",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/ /bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ɪt/ /jɛt/"
 	},
@@ -855,12 +855,12 @@
 		"soundmark": "/bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ɪt/ /jɛt/ /bɪ'kɔz/ /hi/ /ɪz/ /tu/ /'bɪzi/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树",
 		"english": "he has bought a Christmas tree for his family",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/"
 	},
 	{
-		"chinese": "他为了他的家庭(已经)买了一棵圣诞树但是迄今为止他(还没有)装饰它因为他太忙了",
+		"chinese": "他为他的家庭(已经)买了一棵圣诞树但是迄今为止他(还没有)装饰它因为他太忙了",
 		"english": "he has bought a Christmas tree for his family but he hasn't decorated it yet because he is too busy",
 		"soundmark": "/hi/ /hæz/ /bɔt/ /ə/ /ˈkrɪsməs/ /tri/ /fɝ/ /hɪz/ /ˈfæməli/ /bʌt/ /hi/ /ˈhæzənt/ /ˈdɛkəretɪd/ /ɪt/ /jɛt/ /bɪ'kɔz/ /hi/ /ɪz/ /tu/ /'bɪzi/"
 	}

--- a/packages/xingrong-courses/data/courses/50.json
+++ b/packages/xingrong-courses/data/courses/50.json
@@ -40,7 +40,7 @@
 		"soundmark": "/aɪ/ /æm/ /ə/ /'titʃɚ/"
 	},
 	{
-		"chinese": "我(已经)是一名老师了",
+		"chinese": "我(已经)成为一名老师了",
 		"english": "I have been a teacher",
 		"soundmark": "/aɪ/ /hæv/ /bɪn/ /ə/ /'titʃɚ/"
 	},
@@ -55,7 +55,7 @@
 		"soundmark": "/faɪv/ /jɪrz/"
 	},
 	{
-		"chinese": "我(已经)是一名老师五年了",
+		"chinese": "我(已经)成为一名老师五年了",
 		"english": "I have been a teacher for five years",
 		"soundmark": "/aɪ/ /hæv/ /bɪn/ /ə/ /'titʃɚ/ /fɚ/ /faɪv/ /jɪrz/"
 	},
@@ -65,7 +65,7 @@
 		"soundmark": "/sɪns/ /twenty nineteen/ /'twɛnti/ /ˌnaɪn'tin/"
 	},
 	{
-		"chinese": "我自从2019年(已经)是一名老师了",
+		"chinese": "我自从2019年以来(已经)成为了一名老师",
 		"english": "I have been a teacher since 2019",
 		"soundmark": "/aɪ/ /hæv/ /bɪn/ /ə/ /'titʃɚ/ /sɪns/ /'twɛnti/ /ˌnaɪn'tin/"
 	},
@@ -80,12 +80,12 @@
 		"soundmark": "/hi/ /ɪz/ /ə/ /'dɑktɚ/"
 	},
 	{
-		"chinese": "他(已经)是一名医生了",
+		"chinese": "他(已经)成为一名医生了",
 		"english": "he has been a doctor",
 		"soundmark": "/hi/ /hæz/ /bɪn/ /ə/ /'dɑktɚ/"
 	},
 	{
-		"chinese": "他(已经)是一名医生15年了",
+		"chinese": "他(已经)成为一名医生15年了",
 		"english": "he has been a doctor for 15 years",
 		"soundmark": "/hi/ /hæz/ /bɪn/ /ə/ /'dɑktɚ/ /fɚ/ /ˌfɪfˈtin/ /jɪrz/"
 	},
@@ -175,7 +175,7 @@
 		"soundmark": "/sɪns/ /ˈkɪndɚɡɑrtn/"
 	},
 	{
-		"chinese": "他们自从幼儿园(已经)是朋友了",
+		"chinese": "他们自从幼儿园以来(已经)就是朋友了",
 		"english": "they have been friends since kindergarten",
 		"soundmark": "/ðe/ /hæv/ /bɪn/ /frɛndz/ /sɪns/ /ˈkɪndɚɡɑrtn/"
 	},
@@ -210,7 +210,7 @@
 		"soundmark": "/sɪns/ /ˈtʃaɪldhʊd/"
 	},
 	{
-		"chinese": "我们自从童年(已经)是朋友了",
+		"chinese": "我们自从童年以来(已经)就是朋友了",
 		"english": "we have been friends since childhood",
 		"soundmark": "/wi/ /hæv/ /bɪn/ /frɛndz/ /sɪns/ /ˈtʃaɪldhʊd/"
 	},

--- a/packages/xingrong-courses/data/courses/51.json
+++ b/packages/xingrong-courses/data/courses/51.json
@@ -10,12 +10,12 @@
 		"soundmark": "/mɪ'stek/"
 	},
 	{
-		"chinese": "产生一个错误",
+		"chinese": "犯了一个错误",
 		"english": "to make a mistake",
 		"soundmark": "/tə/ /mek/ /ə/ /mɪ'stek/"
 	},
 	{
-		"chinese": "我产生一个错误",
+		"chinese": "我犯了一个错误",
 		"english": "I make a mistake",
 		"soundmark": "/aɪ/ /mek/ /ə/ /mɪ'stek/"
 	},


### PR DESCRIPTION
为中文语义优化做了些努力 [#387](https://github.com/cuixueshe/earthworm/issues/387)

有些语句虽然是有点不通顺，但是和上下文的单词或想要考察的意思是有关联的，作为一个用户的角度，有时感觉反而不通顺的语句，能让我更好的输入英语句子，有些句子好纠结到底要不要修改的更具语义化，感觉这种需要仔细斟酌或是之后在使用过程有明显的痛点再去优化。例如在本次 commit 中，对于例子 1 我就没做优化，例子 2 我做了一下优化。可能我在修改的过程中也有漏字错字多字或是一些不恰当的地方，请多包涵，更新的文件可能有点多，辛苦查看这个 commit 的朋友了。

例如：
1. he keeps forgetting his keys at home ，原先的翻译是 "他总是忘记他的钥匙在家里" 如果改成 "他总是把他的钥匙忘在（落在）家里" ，那么当学习到这个句子时，也许可能不能正确的输入原定的英语句子
2. he finished reading the book，原先的翻译是 "他(过去)完成阅读这本书" 改成 "他读完了这本书" 会更好吗？
3. to watch a movie 在 16.json 是 看一个电影，在 51.json 中是 看电影，这个改不改都不影响大意，也许从保持一致的角度来说值得统一一下

另：我看到 readme 中有提到关于如何正确更新课程数据的一个命令 `pnpm db:update` ，我不知道我需不需要执行这个命令，所以我并没有执行这行命令，只是更新了 json 文件