### PR TITLE
fix: change the style of the prev/next question btn on the game page

### DIFF
--- a/apps/client/components/main/Game.vue
+++ b/apps/client/components/main/Game.vue
@@ -12,6 +12,7 @@
       </template>
     </div>
   </div>
+  <PrevAndNextBtn />
   <Tips></Tips>
   <Summary></Summary>
   <Share></Share>
@@ -24,6 +25,7 @@ import { useGameMode } from "~/composables/main/game";
 import Answer from "./Answer.vue";
 import AnswerTip from "./AnswerTip.vue";
 import AuthRequired from "./AuthRequired.vue";
+import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 import Question from "./Question/Question.vue";
 import Share from "./Share.vue";
 import Summary from "./Summary.vue";

--- a/apps/client/components/main/Game.vue
+++ b/apps/client/components/main/Game.vue
@@ -1,18 +1,16 @@
 <template>
   <div class="h-full pt-20">
-    <PrevAndNextBtn>
-      <div class="h-[40vh] flex flex-col justify-center relative">
-        <template v-if="isQuestion()">
-          <Question></Question>
-          <template v-if="isAnswerTip()">
-            <AnswerTip></AnswerTip>
-          </template>
+    <div class="h-[40vh] flex flex-col justify-center relative">
+      <template v-if="isQuestion()">
+        <Question></Question>
+        <template v-if="isAnswerTip()">
+          <AnswerTip></AnswerTip>
         </template>
-        <template v-else-if="isAnswer()">
-          <Answer></Answer>
-        </template>
-      </div>
-    </PrevAndNextBtn>
+      </template>
+      <template v-else-if="isAnswer()">
+        <Answer></Answer>
+      </template>
+    </div>
   </div>
   <Tips></Tips>
   <Summary></Summary>
@@ -26,7 +24,6 @@ import { useGameMode } from "~/composables/main/game";
 import Answer from "./Answer.vue";
 import AnswerTip from "./AnswerTip.vue";
 import AuthRequired from "./AuthRequired.vue";
-import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 import Question from "./Question/Question.vue";
 import Share from "./Share.vue";
 import Summary from "./Summary.vue";

--- a/apps/client/components/main/Game.vue
+++ b/apps/client/components/main/Game.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="h-full pt-20">
-    <div class="h-[40vh] flex flex-col justify-center relative">
-      <template v-if="isQuestion()">
-        <Question></Question>
-        <template v-if="isAnswerTip()">
-          <AnswerTip></AnswerTip>
+    <PrevAndNextBtn>
+      <div class="h-[40vh] flex flex-col justify-center relative">
+        <template v-if="isQuestion()">
+          <Question></Question>
+          <template v-if="isAnswerTip()">
+            <AnswerTip></AnswerTip>
+          </template>
         </template>
-      </template>
-      <template v-else-if="isAnswer()">
-        <Answer></Answer>
-      </template>
-    </div>
+        <template v-else-if="isAnswer()">
+          <Answer></Answer>
+        </template>
+      </div>
+    </PrevAndNextBtn>
   </div>
   <Tips></Tips>
   <Summary></Summary>
@@ -24,6 +26,7 @@ import { useGameMode } from "~/composables/main/game";
 import Answer from "./Answer.vue";
 import AnswerTip from "./AnswerTip.vue";
 import AuthRequired from "./AuthRequired.vue";
+import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 import Question from "./Question/Question.vue";
 import Share from "./Share.vue";
 import Summary from "./Summary.vue";

--- a/apps/client/components/main/PrevAndNextBtn.vue
+++ b/apps/client/components/main/PrevAndNextBtn.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="flex items-center justify-between">
+  <div
+    class="flex items-center justify-between absolute left-0 right-0 bottom-[14vh] xl:w-[1200px] m-auto xl:px-2 px-24"
+  >
     <!-- left arrow button: go to previous question -->
     <div class="w-12 h-12">
       <button
-        class="arrow-btn tooltip"
+        class="arrow-btn tooltip z-10"
         :data-tip="PREV_BTN_TIP"
         @click="goToPreviousQuestion"
         v-show="courseStore.statementIndex !== 0"
@@ -25,15 +27,16 @@
         </svg>
       </button>
     </div>
-    <slot></slot>
     <!-- right arrow button: go to next question -->
     <div class="w-12 h-12">
       <button
-        class="arrow-btn tooltip"
+        class="arrow-btn tooltip z-10"
         @click="goToNextQuestion"
-        :data-tip="NEXT_BTN_TIP"totalQuestionsCount
-        v-show="courseStore.statementIndex + 1 !== courseStore.totalQuestionsCount"
-
+        :data-tip="NEXT_BTN_TIP"
+        totalQuestionsCount
+        v-show="
+          courseStore.statementIndex + 1 !== courseStore.totalQuestionsCount
+        "
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/apps/client/components/main/PrevAndNextBtn.vue
+++ b/apps/client/components/main/PrevAndNextBtn.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="flex items-center justify-between">
+    <!-- left arrow button: go to previous question -->
+    <div class="w-12 h-12">
+      <button
+        class="arrow-btn tooltip"
+        :data-tip="PREV_BTN_TIP"
+        @click="goToPreviousQuestion"
+        v-show="courseStore.statementIndex !== 0"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="3em"
+          height="3em"
+          viewBox="0 0 24 24"
+        >
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+            d="m15 5l-6 7l6 7"
+          />
+        </svg>
+      </button>
+    </div>
+    <slot></slot>
+    <!-- right arrow button: go to next question -->
+    <div class="w-12 h-12">
+      <button
+        class="arrow-btn tooltip"
+        @click="goToNextQuestion"
+        :data-tip="NEXT_BTN_TIP"totalQuestionsCount
+        v-show="courseStore.statementIndex + 1 !== courseStore.totalQuestionsCount"
+
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="3em"
+          height="3em"
+          viewBox="0 0 24 24"
+        >
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+            d="m9 5l6 7l-6 7"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
+import { useGameMode } from "~/composables/main/game";
+import { useSummary } from "~/composables/main/summary";
+import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
+import { useCourseStore } from "~/store/course";
+import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
+
+const { shortcutKeys } = useShortcutKeyMode();
+const { goToNextQuestion, goToPreviousQuestion } = usePrevAndNextQuestion(
+  shortcutKeys.value.previous,
+  shortcutKeys.value.skip
+);
+
+const PREV_BTN_TIP = `点击跳转至上一题 ( 快捷键: ${shortcutKeys.value.previous} )`;
+const NEXT_BTN_TIP = `点击跳转至下一题 ( 快捷键: ${shortcutKeys.value.skip} )`;
+
+const { showQuestion } = useGameMode();
+const { showSummary } = useSummary();
+const courseStore = useCourseStore();
+
+// 上一题/下一题
+function usePrevAndNextQuestion(prevKey: string, nextKey: string) {
+  handleShortcut();
+
+  function goToNextQuestion() {
+    if (courseStore.isAllDone()) {
+      showSummary();
+      return;
+    }
+    courseStore.toNextStatement();
+    showQuestion();
+  }
+
+  function goToPreviousQuestion() {
+    courseStore.toPreviousStatement();
+    showQuestion();
+  }
+
+  function handleShortcut() {
+    onMounted(() => {
+      registerShortcut(nextKey, goToNextQuestion);
+      registerShortcut(prevKey, goToPreviousQuestion);
+    });
+
+    onUnmounted(() => {
+      cancelShortcut(prevKey, goToNextQuestion);
+      cancelShortcut(nextKey, goToPreviousQuestion);
+    });
+  }
+
+  return {
+    goToNextQuestion,
+    goToPreviousQuestion,
+  };
+}
+</script>
+<style scoped>
+.arrow-btn {
+  @apply text-[#475569] hover:text-[#d946ef] dark:text-[#cbd5e1] dark:hover:text-[#d946ef];
+}
+</style>

--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -1,6 +1,5 @@
 <template>
-<PrevAndNextBtn>
-  <div class="flex flex-col items-center">
+  <div class="absolute left-0 right-0 bottom-[12vh] flex flex-col items-center">
     <div class="mb-4">
       <button
         class="tip-btn"
@@ -24,7 +23,6 @@
       <span class="ml-2">{{ spaceTipText }} </span>
     </div>
   </div>
-  </PrevAndNextBtn>
 </template>
 
 <script setup lang="ts">
@@ -35,7 +33,6 @@ import { useGameMode } from "~/composables/main/game";
 import { useSummary } from "~/composables/main/summary";
 import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
-import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 
 const { shortcutKeys } = useShortcutKeyMode();
 const { playSound } = usePlaySound(shortcutKeys.value.sound);
@@ -129,7 +126,6 @@ function useShowAnswer(key: string) {
     toggleGameMode,
   };
 }
-
 </script>
 
 <style scoped>

--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -18,24 +18,6 @@
       </button>
       <span class="ml-2">{{ toggleTipText }}</span>
     </div>
-    <div class="mb-4">
-      <button
-        class="mr-1 tip-btn"
-        @click="goToPreviousQuestion"
-      >
-        ⌃ {{ shortcutKeys.previous }}
-      </button>
-      <span class="ml-2">上一题</span>
-    </div>
-    <div class="mb-4">
-      <button
-        class="mr-1 tip-btn"
-        @click="goToNextQuestion"
-      >
-        ⌃ {{ shortcutKeys.skip }}
-      </button>
-      <span class="ml-2">下一题</span>
-    </div>
     <div>
       <button class="tip-btn">Space</button>
       <span class="ml-2">{{ spaceTipText }} </span>
@@ -50,20 +32,11 @@ import { useCurrentStatementEnglishSound } from "~/composables/main/englishSound
 import { useGameMode } from "~/composables/main/game";
 import { useSummary } from "~/composables/main/summary";
 import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
-import { useCourseStore } from "~/store/course";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
 
 const { shortcutKeys } = useShortcutKeyMode();
 const { playSound } = usePlaySound(shortcutKeys.value.sound);
 const { toggleGameMode } = useShowAnswer(shortcutKeys.value.answer);
-const { goToNextQuestion, goToPreviousQuestion } = usePrevAndNextQuestion(
-  shortcutKeys.value.previous,
-  shortcutKeys.value.skip
-);
-
-const { showQuestion } = useGameMode();
-const { showSummary } = useSummary();
-const courseStore = useCourseStore();
 
 const toggleTipText = computed(() => {
   let text = "";
@@ -154,41 +127,6 @@ function useShowAnswer(key: string) {
   };
 }
 
-// 上一题/下一题
-function usePrevAndNextQuestion(prevKey: string, nextKey: string) {
-  handleShortcut();
-
-  function goToNextQuestion() {
-    if (courseStore.isAllDone()) {
-      showSummary();
-      return;
-    }
-    courseStore.toNextStatement();
-    showQuestion();
-  }
-
-  function goToPreviousQuestion() {
-    courseStore.toPreviousStatement();
-    showQuestion();
-  }
-
-  function handleShortcut() {
-    onMounted(() => {
-      registerShortcut(nextKey, goToNextQuestion);
-      registerShortcut(prevKey, goToPreviousQuestion);
-    });
-
-    onUnmounted(() => {
-      cancelShortcut(prevKey, goToNextQuestion);
-      cancelShortcut(nextKey, goToPreviousQuestion);
-    });
-  }
-
-  return {
-    goToNextQuestion,
-    goToPreviousQuestion,
-  };
-}
 </script>
 
 <style scoped>

--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="absolute left-0 right-0 bottom-[12vh] flex flex-col items-center">
+<PrevAndNextBtn>
+  <div class="flex flex-col items-center">
     <div class="mb-4">
       <button
         class="tip-btn"
@@ -23,6 +24,7 @@
       <span class="ml-2">{{ spaceTipText }} </span>
     </div>
   </div>
+  </PrevAndNextBtn>
 </template>
 
 <script setup lang="ts">
@@ -33,6 +35,7 @@ import { useGameMode } from "~/composables/main/game";
 import { useSummary } from "~/composables/main/summary";
 import { useShortcutKeyMode } from "~/composables/user/shortcutKey";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
+import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 
 const { shortcutKeys } = useShortcutKeyMode();
 const { playSound } = usePlaySound(shortcutKeys.value.sound);


### PR DESCRIPTION
related to issue #430 

- 修改 上一题/下一题 按钮样式
<img width="1246" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/b88e95e0-6185-4ace-92d7-7e3cc601f2e2">

- 为 上一题/下一题 按钮添加 tooltip
<img width="818" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/970f06b5-d7cc-4bda-9861-00cb2dd84f6b">

- 当题目为第一题时，隐藏上一题按钮；当题目为第最后一题时，隐藏下一题按钮
<img width="1243" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/da7ee38d-5685-4a70-93c0-29db38b3f0c7">
<img width="1301" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/2f1fa0d9-f23e-4874-9de4-af7b161e0fb8">

- 删除原上一题/下一题 按钮
<img width="1424" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/2a43acfe-903a-4215-a184-006f90c72d89">
