### PR TITLE
fix: hide the answer tip  when clicking on the next or previous question

### DIFF
--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -158,7 +158,15 @@ function useShowAnswer(key: string) {
 function usePrevAndNextQuestion(prevKey: string, nextKey: string) {
   handleShortcut();
 
+  function shouldHideAnswerTip() {
+    const { isAnswerTip, hiddenAnswerTip } = useAnswerTip();
+    if (isAnswerTip()) {
+      hiddenAnswerTip();
+    }
+  }
+
   function goToNextQuestion() {
+    shouldHideAnswerTip();
     if (courseStore.isAllDone()) {
       showSummary();
       return;
@@ -168,6 +176,7 @@ function usePrevAndNextQuestion(prevKey: string, nextKey: string) {
   }
 
   function goToPreviousQuestion() {
+    shouldHideAnswerTip();
     courseStore.toPreviousStatement();
     showQuestion();
   }


### PR DESCRIPTION
展示答案提示时，点击上/下一题则隐藏答案提示