### PR TITLE
fix: Fix the bug of resetting progress in the game page

### DIFF
--- a/apps/client/components/main/Question/Question.vue
+++ b/apps/client/components/main/Question/Question.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="text-center pt-2">
-    <div class="flex relative flex-wrap justify-center gap-2 transition-all">
+  <div class="pt-2 text-center">
+    <div class="relative flex flex-wrap justify-center gap-2 transition-all">
       <template
         v-for="(w, i) in courseStore.words"
         :key="i"
@@ -15,7 +15,7 @@
       </template>
       <input
         ref="inputEl"
-        class="absolute h-full w-full opacity-0"
+        class="absolute w-full h-full opacity-0"
         type="text"
         v-model="inputValue"
         @keydown="handleKeydown"
@@ -60,10 +60,11 @@ const { playRightSound, playErrorSound } = usePlayTipSound();
 const {
   inputValue,
   userInputWords,
+  isFixMode,
   submitAnswer,
   setInputValue,
+  setupUserInputWords,
   handleKeyboardInput,
-  isFixMode,
 } = useInput({
   source: () => courseStore.currentStatement?.english!,
   setInputCursorPosition,
@@ -79,23 +80,24 @@ watch(
   }
 );
 
-// 监听当前isDoAgain变化，更新输入框焦点 清除输入框内容
+// 监听当前 isDoAgain 变化，更新输入框焦点 清除输入框内容
 watch(
   () => courseStore.isDoAgain,
   (val) => {
-    if(val){
-      setInputValue(''),
-      handleInputFocus()
-      courseStore.isDoAgain = false
+    if (val) {
+      courseStore.isDoAgain = false;
+      setupUserInputWords();
+      handleInputFocus();
     }
   }
 );
 
-// 监听statementIndex变化，更新输入框焦点 用于解决点击上一题/下一题按钮后，输入框失去聚焦的问题
+// 监听 statementIndex 变化，更新输入框焦点，用于解决点击上一题/下一题/目录跳转按钮后，输入框失去聚焦的问题
 watch(
   () => courseStore.statementIndex,
   () => {
-      handleInputFocus()
+    setupUserInputWords();
+    handleInputFocus();
   }
 );
 

--- a/apps/client/components/main/Question/Question.vue
+++ b/apps/client/components/main/Question/Question.vue
@@ -79,6 +79,26 @@ watch(
   }
 );
 
+// 监听当前isDoAgain变化，更新输入框焦点 清除输入框内容
+watch(
+  () => courseStore.isDoAgain,
+  (val) => {
+    if(val){
+      setInputValue(''),
+      handleInputFocus()
+      courseStore.isDoAgain = false
+    }
+  }
+);
+
+// 监听statementIndex变化，更新输入框焦点 用于解决点击上一题/下一题按钮后，输入框失去聚焦的问题
+watch(
+  () => courseStore.statementIndex,
+  () => {
+      handleInputFocus()
+  }
+);
+
 function getWordsClassNames(index: number) {
   const word = userInputWords[index];
   // 当前单词激活 且 聚焦

--- a/apps/client/composables/main/question.ts
+++ b/apps/client/composables/main/question.ts
@@ -1,4 +1,4 @@
-import { nextTick, reactive, ref, watchEffect } from "vue";
+import { nextTick, reactive, ref } from "vue";
 
 interface Word {
   text: string;
@@ -62,19 +62,17 @@ export function useInput({
   }
 
   function setupUserInputWords() {
-    watchEffect(() => {
-      resetUserInputWords();
+    resetUserInputWords();
 
-      const english = source();
-      english
-        .split(separator)
-        .map(createWord)
-        .forEach((word, i) => {
-          userInputWords[i] = word;
-          // 首个单词自动聚焦
-          i === 0 && (userInputWords[0].isActive = true);
-        });
-    });
+    const english = source();
+    english
+      .split(separator)
+      .map(createWord)
+      .forEach((word, i) => {
+        userInputWords[i] = word;
+        // 首个单词自动聚焦
+        i === 0 && (userInputWords[0].isActive = true);
+      });
   }
 
   function userInputWordsSyncInput() {
@@ -90,7 +88,6 @@ export function useInput({
 
     inputValue.value.split(separator).forEach((input, index) => {
       userInputWords[index].userInput = input;
-
       userInputWords[index].start = position;
       userInputWords[index].end = position + input.length;
 
@@ -375,7 +372,7 @@ export function useInput({
     handleKeyboardInput,
     fixIncorrectWord,
     fixFirstIncorrectWord,
-    resetUserInputWords,
+    setupUserInputWords,
     isFixMode,
   };
 }

--- a/apps/client/store/course.ts
+++ b/apps/client/store/course.ts
@@ -23,6 +23,7 @@ export const useCourseStore = defineStore("course", () => {
   const currentCourse = ref<Course>();
   const statementIndex = ref(0);
   const currentStatement = ref<Statement>();
+  const isDoAgain = ref(false);
 
   const { updateActiveCourseId } = useActiveCourseId();
   const { saveProgress, loadProgress, cleanProgress } = useCourseProgress();
@@ -71,6 +72,7 @@ export const useCourseStore = defineStore("course", () => {
   }
 
   function doAgain() {
+    isDoAgain.value = true;
     resetStatementIndex();
     updateActiveCourseId(currentCourse.value?.id!);
   }
@@ -115,6 +117,7 @@ export const useCourseStore = defineStore("course", () => {
     currentStatement,
     words,
     totalQuestionsCount,
+    isDoAgain,
     setup,
     doAgain,
     isAllDone,


### PR DESCRIPTION
related to issue #444 

- CourseStore 中新增 isDoAgain
- 移除 setupUserInputWords 中的 watchEffect，手动控制触发

> 解决问题

1. 点击重置按钮后，输入框自动聚焦 + 自动清除输入内容
2. 点击上一题/下一题按钮，输入框自动聚焦 + 清除
3. 点击目录跳转指定题目，输入框自动聚焦 + 清除