### PR TITLE
fix: optimize the style and operation of the title catalog

### DIFF
--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="contents"
-    class="absolute top-24 left-0 w-56 z-10 border-l-4 border-fuchsia-500 pl-2 select-none bg-white dark:bg-slate-800 shadow p-2"
+    class="absolute top-24 left-0 w-80 z-10 border-l-4 border-fuchsia-500 pl-2 select-none bg-white dark:bg-slate-800 shadow p-2"
     :class="[isShowContents() && 'show']"
     v-bind="containerProps"
   >
@@ -16,7 +16,7 @@
         <div class="flex">
           <span>{{ item.index + 1 }}</span>
           <span>&nbsp-&nbsp</span>
-          <span class="flex-1">{{ item.data.chinese }}</span>
+          <span class="flex-1 truncate">{{ item.data.chinese }}</span>
         </div>
       </div>
     </div>
@@ -29,7 +29,7 @@ import { computed, onMounted } from "vue";
 import { useCourseStore } from "~/store/course";
 import { useContent } from "./useContents";
 
-const { isShowContents, watchClickOutside } = useContent();
+const { toggleContents,isShowContents, watchClickOutside } = useContent();
 
 const coursesStore = useCourseStore();
 
@@ -56,6 +56,7 @@ function isActive(index: number) {
 }
 
 function jumpTo(index: number) {
+  toggleContents()
   coursesStore.toSpecificStatement(index);
 }
 

--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -13,7 +13,7 @@
         :class="getItemClassNames(item.index)"
         @click="jumpTo(item.index)"
       >
-        <div class="flex">
+        <div class="flex tooltip" :data-tip="item.data.chinese">
           <span>{{ item.index + 1 }}</span>
           <span>&nbsp-&nbsp</span>
           <span class="flex-1 truncate">{{ item.data.chinese }}</span>


### PR DESCRIPTION
related to issue #448 

> 解决问题

1.  宽度改为 20rem
2. 标题添加 Text Overflow
3. 跳转后自动收起目录
4. 添加tooltip
<img width="328" alt="image" src="https://github.com/cuixueshe/earthworm/assets/67595284/8c10ac33-9653-4e0a-99c6-2373af094c0c">
