### PR TITLE
fix: adjust game page display

### DIFF
--- a/apps/client/components/main/Answer.vue
+++ b/apps/client/components/main/Answer.vue
@@ -18,6 +18,9 @@
     <div class="my-6 text-xl text-gray-500">
       {{ courseStore.currentStatement?.soundmark }}
     </div>
+    <div class="my-6 text-xl text-gray-500">
+      {{ courseStore.currentStatement?.chinese }}
+    </div>
     <button
       class="btn-item"
       @click="showQuestion"

--- a/apps/client/components/main/AnswerTip.vue
+++ b/apps/client/components/main/AnswerTip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute left-0 flex items-center justify-center w-full text-xl top-36 dark:text-gray-50"
+    class="absolute flex items-center justify-center w-3/4 text-xl top-36 dark:text-gray-50"
   >
     <div class="shadow-xl card bg-base-100">
       <div class="relative card-body">

--- a/apps/client/components/main/AnswerTip.vue
+++ b/apps/client/components/main/AnswerTip.vue
@@ -1,12 +1,12 @@
 <template>
   <div
-    class="absolute top-[-50px] left-0 w-full flex items-center justify-center text-xl dark:text-gray-50"
+    class="absolute left-0 flex items-center justify-center w-full text-xl top-36 dark:text-gray-50"
   >
-    <div class="card bg-base-100 shadow-xl">
-      <div class="card-body relative">
-        <div class="absolute top-1 right-2 mt-0">
+    <div class="shadow-xl card bg-base-100">
+      <div class="relative card-body">
+        <div class="absolute mt-0 top-1 right-2">
           <button
-            class="w-6 h-6 outline-none dark:text-gray-300 text-gray-400"
+            class="w-6 h-6 text-gray-400 outline-none dark:text-gray-300"
             @click="hiddenAnswerTip"
           >
             <svg

--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="contents"
-    class="absolute left-0 z-10 overflow-x-hidden bg-white border-l-4 shadow select-none top-20 w-80 border-fuchsia-500 dark:bg-slate-800"
+    class="absolute left-0 z-20 overflow-x-hidden bg-white border-l-4 shadow select-none top-20 w-80 border-fuchsia-500 dark:bg-slate-800"
     :class="[isShowContents() && 'show']"
     v-bind="containerProps"
   >

--- a/apps/client/components/main/Game.vue
+++ b/apps/client/components/main/Game.vue
@@ -1,18 +1,15 @@
 <template>
-  <div class="h-full pt-20">
-    <div class="h-[40vh] flex flex-col justify-center relative">
-      <template v-if="isQuestion()">
-        <Question></Question>
-        <template v-if="isAnswerTip()">
-          <AnswerTip></AnswerTip>
-        </template>
+  <div class="flex items-center justify-center h-full">
+    <template v-if="isQuestion()">
+      <Question></Question>
+      <template v-if="isAnswerTip()">
+        <AnswerTip></AnswerTip>
       </template>
-      <template v-else-if="isAnswer()">
-        <Answer></Answer>
-      </template>
-    </div>
+    </template>
+    <template v-else-if="isAnswer()">
+      <Answer></Answer>
+    </template>
   </div>
-  <PrevAndNextBtn />
   <Tips></Tips>
   <Summary></Summary>
   <Share></Share>
@@ -25,7 +22,6 @@ import { useGameMode } from "~/composables/main/game";
 import Answer from "./Answer.vue";
 import AnswerTip from "./AnswerTip.vue";
 import AuthRequired from "./AuthRequired.vue";
-import PrevAndNextBtn from "./PrevAndNextBtn.vue";
 import Question from "./Question/Question.vue";
 import Share from "./Share.vue";
 import Summary from "./Summary.vue";

--- a/apps/client/components/main/PrevAndNextBtn.vue
+++ b/apps/client/components/main/PrevAndNextBtn.vue
@@ -1,11 +1,9 @@
 <template>
-  <div
-    class="flex items-center justify-between absolute left-0 right-0 bottom-[14vh] xl:w-[1200px] m-auto xl:px-2 px-24"
-  >
+  <div class="absolute flex items-center justify-between w-full">
     <!-- left arrow button: go to previous question -->
     <div class="w-12 h-12">
       <button
-        class="arrow-btn tooltip z-10"
+        class="arrow-btn tooltip"
         :data-tip="PREV_BTN_TIP"
         @click="goToPreviousQuestion"
         v-show="courseStore.statementIndex !== 0"
@@ -30,7 +28,7 @@
     <!-- right arrow button: go to next question -->
     <div class="w-12 h-12">
       <button
-        class="arrow-btn tooltip z-10"
+        class="arrow-btn tooltip"
         @click="goToNextQuestion"
         :data-tip="NEXT_BTN_TIP"
         totalQuestionsCount

--- a/apps/client/components/main/Question/Question.vue
+++ b/apps/client/components/main/Question/Question.vue
@@ -1,12 +1,17 @@
 <template>
-  <div class="text-center pt-2">
-    <div class="flex relative flex-wrap justify-center gap-2 transition-all">
+  <div class="text-center">
+    <div class="mt-10 mb-4 text-2xl dark:text-gray-50">
+      {{
+        courseStore.currentStatement?.chinese || "生存还是毁灭，这是一个问题"
+      }}
+    </div>
+    <div class="relative flex flex-wrap justify-center gap-2 transition-all">
       <template
         v-for="(w, i) in courseStore.words"
         :key="i"
       >
         <div
-          class="h-[4.8rem] border-solid rounded-[2px] border-b-2 text-[3.2em] transition-all"
+          class="h-[4rem] leading-none border-solid rounded-[2px] border-b-2 text-[3em] transition-all"
           :class="getWordsClassNames(i)"
           :style="{ minWidth: `${inputWidth(w)}ch` }"
         >
@@ -15,7 +20,7 @@
       </template>
       <input
         ref="inputEl"
-        class="absolute h-full w-full opacity-0"
+        class="absolute w-full h-full opacity-0"
         type="text"
         v-model="inputValue"
         @keydown="handleKeydown"
@@ -25,11 +30,6 @@
         @mousedown="preventCursorMove"
         autoFocus
       />
-    </div>
-    <div class="mt-12 text-xl dark:text-gray-50">
-      {{
-        courseStore.currentStatement?.chinese || "生存还是毁灭，这是一个问题"
-      }}
     </div>
   </div>
 </template>

--- a/apps/client/components/main/Tips.vue
+++ b/apps/client/components/main/Tips.vue
@@ -1,43 +1,46 @@
 <template>
-  <div class="absolute left-0 right-0 bottom-[12vh] flex flex-col items-center">
-    <div class="mb-4">
-      <button
-        class="btn btn-ghost"
-        @click="playSound"
-      >
-        <div class="flex items-center justify-center gap-2 text-center">
-          <div
-            v-for="key in parseShortcutKeys(shortcutKeys.sound)"
-            class="kbd"
-          >
-            {{ key }}
+  <div class="relative flex items-center justify-center my-8">
+    <div class="z-10 flex items-center justify-center">
+      <div>
+        <button
+          class="btn btn-ghost"
+          @click="playSound"
+        >
+          <div class="flex items-center justify-center gap-2 text-center">
+            <div
+              v-for="key in parseShortcutKeys(shortcutKeys.sound)"
+              class="kbd"
+            >
+              {{ key }}
+            </div>
           </div>
-        </div>
-        <span>播放发音</span>
-      </button>
-    </div>
-    <div class="mb-4">
-      <button
-        class="btn btn-ghost"
-        @click="toggleGameMode"
-      >
-        <div class="flex items-center justify-center gap-2 text-center">
-          <div
-            v-for="key in parseShortcutKeys(shortcutKeys.answer)"
-            class="kbd"
-          >
-            {{ key }}
+          <span>播放发音</span>
+        </button>
+      </div>
+      <div>
+        <button
+          class="btn btn-ghost"
+          @click="toggleGameMode"
+        >
+          <div class="flex items-center justify-center gap-2 text-center">
+            <div
+              v-for="key in parseShortcutKeys(shortcutKeys.answer)"
+              class="kbd"
+            >
+              {{ key }}
+            </div>
           </div>
-        </div>
-        <span>{{ toggleTipText }}</span>
-      </button>
+          <span>{{ toggleTipText }}</span>
+        </button>
+      </div>
+      <div>
+        <button class="btn btn-ghost">
+          <span class="kbd">Space</span>
+          <span>{{ spaceTipText }} </span>
+        </button>
+      </div>
     </div>
-    <div>
-      <button class="btn btn-ghost">
-        <span class="kbd">Space</span>
-        <span>{{ spaceTipText }} </span>
-      </button>
-    </div>
+    <PrevAndNextBtn />
   </div>
 </template>
 
@@ -53,6 +56,8 @@ import {
   parseShortcutKeys,
   registerShortcut,
 } from "~/utils/keyboardShortcuts";
+import PrevAndNextBtn from "./PrevAndNextBtn.vue";
+
 const { shortcutKeys } = useShortcutKeyMode();
 const { playSound } = usePlaySound(shortcutKeys.value.sound);
 const { toggleGameMode } = useShowAnswer(shortcutKeys.value.answer);


### PR DESCRIPTION
> 关于适配，做了一些微调

1. 游戏页面：底部快捷键区域平铺 ✅
2. 游戏页面：将切换上/下题目组件移动到 Tips 页面中 ✅
3. 答题页面：去除绝对定位 + 调整边距 ✅
4. 答题页面：将中文调整到上面，英文输入部分放下面 ✅
5. 答题页面：调整字体大小与高度 ✅
6. 答案页面：增加中文补充，方便与英文核对含义 ✅
7. 答案预览页面：位置往上一点点 ✅
8. 调整剩余细节（与其他元素的层级显示）✅

**小屏预览 10:5**

![1711892732111](https://github.com/cuixueshe/earthworm/assets/48991003/654d3e7c-6c27-4b96-954b-8ba29ed26ae6)

**iPad mini 10:7**

![1711892790781](https://github.com/cuixueshe/earthworm/assets/48991003/9307f916-a71b-49c5-929b-590c75fb4a20)

![1711897200715](https://github.com/cuixueshe/earthworm/assets/48991003/42b8d6d8-6c9b-41c1-afd7-3330b2712b74)

**正常 PC 用户 1920x1080**

![1711892845092](https://github.com/cuixueshe/earthworm/assets/48991003/b8ab2186-16f6-42bc-8d2f-d4a3333bd191)

**答案预览面板**

![1711896950786](https://github.com/cuixueshe/earthworm/assets/48991003/2870cc48-937f-40b7-b76b-4634713019a4)

**答案页面**

![1711897019093](https://github.com/cuixueshe/earthworm/assets/48991003/4ee4252b-8909-48c1-8499-87fd0d8ebf7d)