### PR TITLE
中文语义的问题：误把动词过去分词形式写成“ed形式”

### DIFF
--- a/packages/xingrong-courses/data/courses/39.json
+++ b/packages/xingrong-courses/data/courses/39.json
@@ -5,7 +5,7 @@
 		"soundmark": "/tə/ /wɔʃ/"
 	},
 	{
-		"chinese": "清洗（ed形式）",
+		"chinese": "清洗（过去分词）",
 		"english": "washed",
 		"soundmark": "/wɔʃt/"
 	},
@@ -65,7 +65,7 @@
 		"soundmark": "/tə/ /'ænsɚ/"
 	},
 	{
-		"chinese": "回答（ed形式）",
+		"chinese": "回答（过去分词）",
 		"english": "answered",
 		"soundmark": "/'ænsɚd/"
 	},
@@ -110,7 +110,7 @@
 		"soundmark": "/tə/ /sɑlv/"
 	},
 	{
-		"chinese": "解决（ed形式）",
+		"chinese": "解决（过去分词）",
 		"english": "solved",
 		"soundmark": "/sɑlvd/"
 	},
@@ -170,7 +170,7 @@
 		"soundmark": "/tə/ /tɛl/"
 	},
 	{
-		"chinese": "告诉（ed形式）",
+		"chinese": "告诉（过去分词）",
 		"english": "told",
 		"soundmark": "/told/"
 	},
@@ -305,7 +305,7 @@
 		"soundmark": "/tə/ /'wɔtɚ/"
 	},
 	{
-		"chinese": "浇水（ed形式）",
+		"chinese": "浇水（过去分词）",
 		"english": "watered",
 		"soundmark": "/'wɔtɚd/"
 	},
@@ -375,7 +375,7 @@
 		"soundmark": "/tə/ /ɪn'vaɪt/"
 	},
 	{
-		"chinese": "邀请（ed形式）",
+		"chinese": "邀请（过去分词）",
 		"english": "invited",
 		"soundmark": "/ɪn'vaɪtɪd/"
 	},
@@ -425,7 +425,7 @@
 		"soundmark": "/tə/ /ək'sɛpt/"
 	},
 	{
-		"chinese": "接受（ed形式）",
+		"chinese": "接受（过去分词）",
 		"english": "accepted",
 		"soundmark": "/ək'sɛptɪd/"
 	},
@@ -545,7 +545,7 @@
 		"soundmark": "/tə/ /'fɪnɪʃ/"
 	},
 	{
-		"chinese": "完成（ed形式）",
+		"chinese": "完成（过去分词）",
 		"english": "finished",
 		"soundmark": "/'fɪnɪʃt/"
 	},
@@ -610,7 +610,7 @@
 		"soundmark": "/tə/ /kʊk/"
 	},
 	{
-		"chinese": "烹饪（ed形式）",
+		"chinese": "烹饪（过去分词）",
 		"english": "cooked",
 		"soundmark": "/kʊkt/"
 	},
@@ -665,7 +665,7 @@
 		"soundmark": "/tə/ /brek/"
 	},
 	{
-		"chinese": "打破（ed形式）",
+		"chinese": "打破（过去分词）",
 		"english": "broken",
 		"soundmark": "/'brokən/"
 	},
@@ -720,7 +720,7 @@
 		"soundmark": "/tə/ /kloz/"
 	},
 	{
-		"chinese": "关闭（ed形式）",
+		"chinese": "关闭（过去分词）",
 		"english": "closed",
 		"soundmark": "/klozd/"
 	},
@@ -765,7 +765,7 @@
 		"soundmark": "/tə/ /kip/"
 	},
 	{
-		"chinese": "保持（ed形式）",
+		"chinese": "保持（过去分词）",
 		"english": "kept",
 		"soundmark": "/kɛpt/"
 	},
@@ -815,7 +815,7 @@
 		"soundmark": "/tə/ /sev/"
 	},
 	{
-		"chinese": "拯救（ed形式）",
+		"chinese": "拯救（过去分词）",
 		"english": "saved",
 		"soundmark": "/sevd/"
 	},
@@ -885,7 +885,7 @@
 		"soundmark": "/tə/ /hold/"
 	},
 	{
-		"chinese": "举行（ed形式）",
+		"chinese": "举行（过去分词）",
 		"english": "held",
 		"soundmark": "/hɛld/"
 	},

--- a/packages/xingrong-courses/data/courses/42.json
+++ b/packages/xingrong-courses/data/courses/42.json
@@ -560,7 +560,7 @@
 		"soundmark": "/tə/ /ək'sɛpt/"
 	},
 	{
-		"chinese": "接受(ed形式)",
+		"chinese": "接受(过去分词)",
 		"english": "accepted",
 		"soundmark": "/ək'sɛptɪd/"
 	},
@@ -630,7 +630,7 @@
 		"soundmark": "/tə/ /ɪn'vaɪt/"
 	},
 	{
-		"chinese": "邀请(ed形式)",
+		"chinese": "邀请(过去分词)",
 		"english": "invited",
 		"soundmark": "/ɪn'vaɪtɪd/"
 	},
@@ -680,7 +680,7 @@
 		"soundmark": "/tə/ /titʃ/"
 	},
 	{
-		"chinese": "教(ed形式)",
+		"chinese": "教(过去分词)",
 		"english": "taught",
 		"soundmark": "/tɔt/"
 	},

--- a/packages/xingrong-courses/data/courses/48.json
+++ b/packages/xingrong-courses/data/courses/48.json
@@ -35,7 +35,7 @@
 		"soundmark": "/bi/ /'wɑʃɪŋ/"
 	},
 	{
-		"chinese": "清洗(ed形式)",
+		"chinese": "清洗(过去分词)",
 		"english": "washed",
 		"soundmark": "/wɑʃt/"
 	},
@@ -75,7 +75,7 @@
 		"soundmark": "/tə/ /'fɪnɪʃ/"
 	},
 	{
-		"chinese": "完成(ed形式)",
+		"chinese": "完成(过去分词)",
 		"english": "finished",
 		"soundmark": "/'fɪnɪʃt/"
 	},
@@ -140,7 +140,7 @@
 		"soundmark": "/tə/ /ɡo/ /tə/ /ðə/ /pɑrk/"
 	},
 	{
-		"chinese": "去(ed形式)",
+		"chinese": "去(过去分词)",
 		"english": "gone",
 		"soundmark": "/ɡɔn/"
 	},
@@ -160,7 +160,7 @@
 		"soundmark": "/tə/ /rid/"
 	},
 	{
-		"chinese": "读(ed形式)",
+		"chinese": "读(过去分词)",
 		"english": "read",
 		"soundmark": "/rid/"
 	},
@@ -205,7 +205,7 @@
 		"soundmark": "/tə/ /lɝn/"
 	},
 	{
-		"chinese": "学到(ed形式)",
+		"chinese": "学到(过去分词)",
 		"english": "learned",
 		"soundmark": "/lɝnd/"
 	},
@@ -260,7 +260,7 @@
 		"soundmark": "/tə/ /ɪmˈpruv/"
 	},
 	{
-		"chinese": "提高(ed形式)",
+		"chinese": "提高(过去分词)",
 		"english": "improved",
 		"soundmark": "/ɪmˈpruvd/"
 	},
@@ -305,7 +305,7 @@
 		"soundmark": "/tə/ /'vɪzɪt/"
 	},
 	{
-		"chinese": "参观(ed形式)",
+		"chinese": "参观(过去分词)",
 		"english": "visited",
 		"soundmark": "/'vɪzɪtɪd/"
 	},
@@ -350,7 +350,7 @@
 		"soundmark": "/raɪt/"
 	},
 	{
-		"chinese": "写(ed形式)",
+		"chinese": "写(过去分词)",
 		"english": "written",
 		"soundmark": "/'rɪtn/"
 	},
@@ -400,7 +400,7 @@
 		"soundmark": "/tə/ /titʃ/"
 	},
 	{
-		"chinese": "教(ed形式)",
+		"chinese": "教(过去分词)",
 		"english": "taught",
 		"soundmark": "/tɔt/"
 	},
@@ -500,7 +500,7 @@
 		"soundmark": "/tə/ /lɪv/"
 	},
 	{
-		"chinese": "居住(ed形式)",
+		"chinese": "居住(过去分词)",
 		"english": "lived",
 		"soundmark": "/lɪvd/"
 	},
@@ -550,7 +550,7 @@
 		"soundmark": "/tə/ /wɝk/"
 	},
 	{
-		"chinese": "工作(ed形式)",
+		"chinese": "工作(过去分词)",
 		"english": "worked",
 		"soundmark": "/wɝkt/"
 	},
@@ -615,7 +615,7 @@
 		"soundmark": "/tə/ /'stʌdi/"
 	},
 	{
-		"chinese": "学习(ed形式)",
+		"chinese": "学习(过去分词)",
 		"english": "studied",
 		"soundmark": "/ˈstʌdid/"
 	},

--- a/packages/xingrong-courses/data/courses/49.json
+++ b/packages/xingrong-courses/data/courses/49.json
@@ -25,7 +25,7 @@
 		"soundmark": "/tə/ /faɪnd/"
 	},
 	{
-		"chinese": "找到(ed形式)",
+		"chinese": "找到(过去分词)",
 		"english": "found",
 		"soundmark": "/faʊnd/"
 	},
@@ -55,7 +55,7 @@
 		"soundmark": "/tə/ /'vɪzɪt/"
 	},
 	{
-		"chinese": "参观(ed形式)",
+		"chinese": "参观(过去分词)",
 		"english": "visited",
 		"soundmark": "/'vɪzɪtɪd/"
 	},
@@ -95,7 +95,7 @@
 		"soundmark": "/tə/ /əˈbændən/"
 	},
 	{
-		"chinese": "遗弃(ed形式)",
+		"chinese": "遗弃(过去分词)",
 		"english": "abandoned",
 		"soundmark": "/ə'bændənd/"
 	},
@@ -295,7 +295,7 @@
 		"soundmark": "/tə/ /traɪ/"
 	},
 	{
-		"chinese": "尝试(ed形式)",
+		"chinese": "尝试(过去分词)",
 		"english": "tried",
 		"soundmark": "/traɪd/"
 	},
@@ -325,7 +325,7 @@
 		"soundmark": "/tə/ /mit/"
 	},
 	{
-		"chinese": "见(ed形式)",
+		"chinese": "见(过去分词)",
 		"english": "met",
 		"soundmark": "/mɛt/"
 	},
@@ -380,7 +380,7 @@
 		"soundmark": "/tə/ /əˈtɛnd/"
 	},
 	{
-		"chinese": "参加(ed形式)",
+		"chinese": "参加(过去分词)",
 		"english": "attended",
 		"soundmark": "/əˈtɛndɪd/"
 	},
@@ -435,7 +435,7 @@
 		"soundmark": "/tə/ /fɪks/"
 	},
 	{
-		"chinese": "修理(ed形式)",
+		"chinese": "修理(过去分词)",
 		"english": "fixed",
 		"soundmark": "/fɪkst/"
 	},
@@ -460,7 +460,7 @@
 		"soundmark": "/tə/ /brek/"
 	},
 	{
-		"chinese": "打破(ed形式)",
+		"chinese": "打破(过去分词)",
 		"english": "broken",
 		"soundmark": "/'brokən/"
 	},
@@ -510,7 +510,7 @@
 		"soundmark": "/tə/ /rɪ'siv/"
 	},
 	{
-		"chinese": "收到(ed形式)",
+		"chinese": "收到(过去分词)",
 		"english": "received",
 		"soundmark": "/rɪ'sivd/"
 	},
@@ -545,7 +545,7 @@
 		"soundmark": "/tə/ /'fɪnɪʃ/"
 	},
 	{
-		"chinese": "完成(ed形式)",
+		"chinese": "完成(过去分词)",
 		"english": "finished",
 		"soundmark": "/'fɪnɪʃt/"
 	},
@@ -675,7 +675,7 @@
 		"soundmark": "/tə/ /baɪ/ /ə/ /ˈkrɪsməs/ /tri/"
 	},
 	{
-		"chinese": "买(ed形式)",
+		"chinese": "买(过去分词)",
 		"english": "bought",
 		"soundmark": "/bɔt/"
 	},
@@ -715,7 +715,7 @@
 		"soundmark": "/tə/ /ˈdɛkəret/"
 	},
 	{
-		"chinese": "装饰(ed形式)",
+		"chinese": "装饰(过去分词)",
 		"english": "decorated",
 		"soundmark": "/ˈdɛkəretɪd/"
 	},
@@ -750,7 +750,7 @@
 		"soundmark": "/tə/ /ˈdɛkəret/"
 	},
 	{
-		"chinese": "装饰(ed形式)",
+		"chinese": "装饰(过去分词)",
 		"english": "decorated",
 		"soundmark": "/ˈdɛkəretɪd/"
 	},

--- a/packages/xingrong-courses/data/courses/50.json
+++ b/packages/xingrong-courses/data/courses/50.json
@@ -20,7 +20,7 @@
 		"soundmark": "/aɪ/ /pe/ /ðə/ /bɪl/"
 	},
 	{
-		"chinese": "支付(ed形式)",
+		"chinese": "支付(过去分词)",
 		"english": "paid",
 		"soundmark": "/ped/"
 	},
@@ -595,7 +595,7 @@
 		"soundmark": "/tə/ /it/"
 	},
 	{
-		"chinese": "吃(ed形式)",
+		"chinese": "吃(过去分词)",
 		"english": "eaten",
 		"soundmark": "/ˈitn/"
 	},
@@ -620,7 +620,7 @@
 		"soundmark": "/tə/ /əˈtɛnd/"
 	},
 	{
-		"chinese": "参加(ed形式)",
+		"chinese": "参加(过去分词)",
 		"english": "attended",
 		"soundmark": "/əˈtɛndɪd/"
 	},
@@ -660,7 +660,7 @@
 		"soundmark": "/tə/ /luz/"
 	},
 	{
-		"chinese": "丢掉(ed形式)",
+		"chinese": "丢掉(过去分词)",
 		"english": "lost",
 		"soundmark": "/lɔst/"
 	},
@@ -690,7 +690,7 @@
 		"soundmark": "/tə/ /si/"
 	},
 	{
-		"chinese": "看(ed形式)",
+		"chinese": "看(过去分词)",
 		"english": "seen",
 		"soundmark": "/sin/"
 	},
@@ -715,7 +715,7 @@
 		"soundmark": "/tə/ /'stʌdi/"
 	},
 	{
-		"chinese": "学习(ed形式)",
+		"chinese": "学习(过去分词)",
 		"english": "studied",
 		"soundmark": "/ˈstʌdid/"
 	},
@@ -745,7 +745,7 @@
 		"soundmark": "/tə/ /mek/"
 	},
 	{
-		"chinese": "做(ed形式)",
+		"chinese": "做(过去分词)",
 		"english": "made",
 		"soundmark": "/med/"
 	},

--- a/packages/xingrong-courses/data/courses/51.json
+++ b/packages/xingrong-courses/data/courses/51.json
@@ -20,7 +20,7 @@
 		"soundmark": "/aɪ/ /mek/ /ə/ /mɪ'stek/"
 	},
 	{
-		"chinese": "产生（ed形式）",
+		"chinese": "产生（过去分词）",
 		"english": "made",
 		"soundmark": "/med/"
 	},
@@ -145,7 +145,7 @@
 		"soundmark": "/tə/ /fes/"
 	},
 	{
-		"chinese": "面对（ed形式）",
+		"chinese": "面对（过去分词）",
 		"english": "faced",
 		"soundmark": "/fest/"
 	},
@@ -195,7 +195,7 @@
 		"soundmark": "/tə/ /mit/"
 	},
 	{
-		"chinese": "见到（ed形式）",
+		"chinese": "见到（过去分词）",
 		"english": "met",
 		"soundmark": "/mɛt/"
 	},
@@ -265,7 +265,7 @@
 		"soundmark": "/tə/ /no/"
 	},
 	{
-		"chinese": "认识（ed形式）",
+		"chinese": "认识（过去分词）",
 		"english": "known",
 		"soundmark": "/non/"
 	},
@@ -325,7 +325,7 @@
 		"soundmark": "/tə/ /hɪr/"
 	},
 	{
-		"chinese": "听到（ed形式）",
+		"chinese": "听到（过去分词）",
 		"english": "heard",
 		"soundmark": "/hɚd/"
 	},
@@ -380,7 +380,7 @@
 		"soundmark": "/tə/ /si/"
 	},
 	{
-		"chinese": "看到（ed形式）",
+		"chinese": "看到（过去分词）",
 		"english": "seen",
 		"soundmark": "/sin/"
 	},
@@ -435,7 +435,7 @@
 		"soundmark": "/tə/ /du/"
 	},
 	{
-		"chinese": "做（ed形式）",
+		"chinese": "做（过去分词）",
 		"english": "done",
 		"soundmark": "/dʌn/"
 	},
@@ -495,7 +495,7 @@
 		"soundmark": "/tə/ /mit/"
 	},
 	{
-		"chinese": "见到（ed形式）",
+		"chinese": "见到（过去分词）",
 		"english": "met",
 		"soundmark": "/mɛt/"
 	},
@@ -575,7 +575,7 @@
 		"soundmark": "/tə/ /mek/"
 	},
 	{
-		"chinese": "做（ed形式）",
+		"chinese": "做（过去分词）",
 		"english": "made",
 		"soundmark": "/med/"
 	},
@@ -635,7 +635,7 @@
 		"soundmark": "/tə/ /'vɪzɪt/"
 	},
 	{
-		"chinese": "参观（ed形式）",
+		"chinese": "参观（过去分词）",
 		"english": "visited",
 		"soundmark": "/'vɪzɪtɪd/"
 	},
@@ -700,7 +700,7 @@
 		"soundmark": "/tə/ /wɑtʃ/"
 	},
 	{
-		"chinese": "看（ed形式）",
+		"chinese": "看（过去分词）",
 		"english": "watched",
 		"soundmark": "/wɑtʃt/"
 	},


### PR DESCRIPTION
修改了部分课程中的中文语义，将 `(ed形式)` 修改为 `(过去分词)` 。