### PR TITLE
fix(client): home router skip bug

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -254,7 +254,10 @@ const handleLogout = () => {
 };
 
 const handleSetting = () => {
-  navigateTo("/user/info");
+  navigateTo({
+    path: "/user/info",
+    query: { displayComponent: "Setting" },
+  });
 };
 
 const handleLogoutConfirm = () => {

--- a/apps/client/components/user/Menu.vue
+++ b/apps/client/components/user/Menu.vue
@@ -17,27 +17,32 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { ref, watch, defineProps, defineEmits } from "vue";
 
 type Menu = {
   name: string;
-  component: any;
+  component: string;
 };
 
 const props = defineProps<{
   menus: Menu[];
+  defaultMenuName: string;
 }>();
 
 const emits = defineEmits(["changeMenu"]);
 
-let currentMenu = ref<string>("");
-const handleChangeMenu = (menu: Menu) => {
+const currentMenu = ref(props.defaultMenuName);
+
+function handleChangeMenu(menu: Menu) {
   currentMenu.value = menu.name;
   emits("changeMenu", menu);
-};
+}
 
-const setDefaultMenu = () => {
-  handleChangeMenu(props.menus[0]);
-};
-onMounted(() => setDefaultMenu());
+watch(
+  () => props.defaultMenuName,
+  newVal => {
+    currentMenu.value = newVal;
+  },
+  { immediate: true }
+);
 </script>

--- a/apps/client/components/user/Menu.vue
+++ b/apps/client/components/user/Menu.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, defineProps, defineEmits } from "vue";
+import { ref, watch } from "vue";
 
 type Menu = {
   name: string;
@@ -40,7 +40,7 @@ function handleChangeMenu(menu: Menu) {
 
 watch(
   () => props.defaultMenuName,
-  newVal => {
+  (newVal) => {
     currentMenu.value = newVal;
   },
   { immediate: true }

--- a/apps/client/pages/User/Info.vue
+++ b/apps/client/pages/User/Info.vue
@@ -2,6 +2,7 @@
   <div class="flex min-h-full flex-1 justify-center px-6 py-12 lg:px-8">
     <UserMenus
       :menus="userMenus"
+      :defaultMenuName="defaultMenuName"
       @changeMenu="handleChangeMenu"
     />
     <div class="flex-1 pl-4">
@@ -11,25 +12,38 @@
 </template>
 
 <script setup lang="ts">
-import { markRaw, ref } from "vue";
-import UserHome from "~/components/user/Home.vue";
+import { computed, ref, watchEffect } from "vue";
+import { useRoute } from "vue-router";
 import UserMenus from "~/components/user/Menu.vue";
+import UserHome from "~/components/user/Home.vue";
 import UserSetting from "~/components/user/Setting.vue";
 
-type Menu = {
-  name: string;
-  component: any;
+const route = useRoute();
+
+const componentMap = {
+  Home: UserHome,
+  Setting: UserSetting,
 };
 
-// [Vue warn]: Vue received a Component that was made a reactive object.
-// This can lead to unnecessary performance overhead and should be avoided
-// by marking the component with `markRaw` or using `shallowRef` instead of `ref`.
-const userMenus = ref<Menu[]>([
-  { name: "主页", component: markRaw(UserHome) },
-  { name: "设置", component: markRaw(UserSetting) },
+const userMenus = ref([
+  { name: "主页", component: "Home" },
+  { name: "设置", component: "Setting" },
 ]);
-let currentComponent = ref<any>();
-const handleChangeMenu = (menu: Menu) => {
-  currentComponent.value = menu.component;
-};
+
+const currentComponent = ref<UserHome | UserSetting>(componentMap.Home);
+
+watchEffect(() => {
+  const routeComponent = route.query.displayComponent;
+  currentComponent.value =
+    componentMap[routeComponent as keyof typeof componentMap] ||
+    componentMap.Home;
+});
+
+function handleChangeMenu(menu) {
+  currentComponent.value = componentMap[menu.component];
+}
+
+const defaultMenuName = computed(() =>
+  route.query.displayComponent === "Setting" ? "设置" : "主页"
+);
 </script>

--- a/apps/client/pages/User/Info.vue
+++ b/apps/client/pages/User/Info.vue
@@ -20,7 +20,17 @@ import UserSetting from "~/components/user/Setting.vue";
 
 const route = useRoute();
 
-const componentMap = {
+interface ComponentMap {
+  Home: typeof UserHome;
+  Setting: typeof UserSetting;
+}
+
+interface Menu {
+  name: string;
+  component: keyof ComponentMap;
+}
+
+const componentMap: ComponentMap = {
   Home: UserHome,
   Setting: UserSetting,
 };
@@ -30,7 +40,7 @@ const userMenus = ref([
   { name: "设置", component: "Setting" },
 ]);
 
-const currentComponent = ref<UserHome | UserSetting>(componentMap.Home);
+const currentComponent = ref(componentMap.Home);
 
 watchEffect(() => {
   const routeComponent = route.query.displayComponent;
@@ -39,7 +49,7 @@ watchEffect(() => {
     componentMap.Home;
 });
 
-function handleChangeMenu(menu) {
+function handleChangeMenu(menu: Menu) {
   currentComponent.value = componentMap[menu.component];
 }
 


### PR DESCRIPTION
1. 修复新首页遗留跳转 bug
- Desc: 
	- 	之前 Account Info 和 Setting 都跳转到 userInfo 页面显示的 Home 组件
![image](https://github.com/cuixueshe/earthworm/assets/88535417/ff66726e-c4cf-429d-a879-4475dd7e335e)
