### PR TITLE
fix(client): home page style question

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="sticky top-0 bg-opacity-50 backdrop-blur-xl z-50 font-customFont px-3"
+    class="sticky top-0 bg-opacity-50 backdrop-blur-xl z-50 font-customFont px-3 w-full"
   >
     <div class="mx-auto max-w-screen-xl mt-2">
       <div class="flex h-16 items-center justify-between">

--- a/apps/client/layouts/default.vue
+++ b/apps/client/layouts/default.vue
@@ -2,11 +2,11 @@
   <div
     class="w-full h-full bg-white dark:bg-theme-dark transition-colors dark:text-slate-300 text-slate-600"
   >
-    <Navbar></Navbar>
     <div
-      class="flex flex-col h-fit min-h-screen xl:w-[1200px] m-auto xl:px-2 px-24"
+      class="flex flex-col h-fit min-h-screen m-auto xl:px-2 px-24 items-center"
     >
-      <div class="flex-1 flex">
+      <Navbar></Navbar>
+      <div class="flex-1 flex xl:w-[1200px]">
         <slot></slot>
       </div>
       <Footer></Footer>

--- a/apps/client/pages/index.vue
+++ b/apps/client/pages/index.vue
@@ -70,8 +70,6 @@ import Comments from "~/components/home/Comments.vue";
 import Contact from "~/components/home/Contact.vue";
 import Features from "~/components/home/Features.vue";
 import NoticeBar from "~/components/home/NoticeBar.vue";
-import PayCard from "~/components/home/PayCard.vue";
-import Question from "~/components/home/Questions.vue";
 const showNoticeBar = ref(false);
 
 import { onMounted, onUnmounted, ref } from "vue";
@@ -131,7 +129,7 @@ function useShortcutToGame() {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 13rem;
+  width: fit-content;
   overflow: hidden;
   height: 3rem;
   background-size: 300% 300%;


### PR DESCRIPTION
1. 修复新首页顶部黑色区域问题；

<img width="1695" alt="9fa48e33404907f4b5b9ee8c5c1f51f" src="https://github.com/cuixueshe/earthworm/assets/88535417/d86eb353-edcd-46fd-8b42-e8a3c0602c95">

2. 修复开始按钮适配 2K 屏幕宽度问题；

<img width="448" alt="d7c9289f0d684d70b10bf9d83a33af8" src="https://github.com/cuixueshe/earthworm/assets/88535417/5d1678dc-e872-4b6f-95d6-9d7ffbc3691f">

3. 修复新页面game页面滚动问题；

<img width="1003" alt="2c21329ca5e5575c5b174abe528228e" src="https://github.com/cuixueshe/earthworm/assets/88535417/07bb2e21-e5b8-4ba7-91ad-4d9e8344210b">
