### PR TITLE
fix：Home navigation bar moves while scrolling

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -2,7 +2,7 @@
   <header
     class="sticky top-0 bg-opacity-50 backdrop-blur-xl z-50 font-customFont px-3 w-full"
   >
-    <div class="mx-auto max-w-screen-xl mt-2">
+    <div class="mx-auto max-w-screen-xl">
       <div class="flex h-16 items-center justify-between">
         <div class="left flex w-full items-center justify-between">
           <NuxtLink to="/">


### PR DESCRIPTION
上下滚动首页时，顶部导航栏因为有一个向上的的 margin-top 所以会动一下