### PR TITLE
feat: add look password button

### DIFF
--- a/apps/client/pages/Auth/FormInput.vue
+++ b/apps/client/pages/Auth/FormInput.vue
@@ -5,24 +5,55 @@
       class="block mt-2 text-sm font-medium text-gray-700 dark:text-gray-300"
       >{{ label }} <span class="text-red-500">*</span></label
     >
-    <input
-      :id="name"
-      :name="name"
-      :value="modelValue"
-      @input="updateValue($event)"
-      :type="type"
-      :placeholder="placeholder"
-      class="mt-2 appearance-none block w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
-      :autocomplete="autocomplete"
-      required
-    />
-    <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">
-      {{ errorMessage }}
-    </p>
+
+    <div class="relative">
+      <input
+        :id="name"
+        :name="name"
+        :value="modelValue"
+        @input="updateValue($event)"
+        :type="inputType"
+        :placeholder="placeholder"
+        :autocomplete="autocomplete"
+        required
+        class="mt-2 appearance-none block w-full px-3 py-2.5 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 text-sm text-gray-700 dark:text-gray-300 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 focus:bg-blue-50 dark:focus:bg-gray-600"
+      />
+
+      <span
+        class="absolute inset-y-0 end-0 grid bottom-1.5 place-content-center px-4 cursor-pointer"
+        v-if="type === 'password'"
+        @click="togglePassword"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="size-4 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+          />
+        </svg>
+      </span>
+      <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">
+        {{ errorMessage }}
+      </p>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 const props = defineProps({
   label: String,
   name: String,
@@ -51,5 +82,10 @@ function updateValue(event: Event) {
     input.value = input.value.replace(/\D/g, "");
   }
   emit("update:modelValue", input.value);
+}
+
+const inputType = ref(props.type);
+function togglePassword() {
+  inputType.value = inputType.value === "password" ? "text" : "password";
 }
 </script>

--- a/apps/client/pages/Auth/hooks/useLoginForm.ts
+++ b/apps/client/pages/Auth/hooks/useLoginForm.ts
@@ -1,4 +1,4 @@
-import { useForm, useField } from "vee-validate";
+import { useField, useForm } from "vee-validate";
 import * as yup from "yup";
 import { type SignupFormValues } from "~/store/user";
 export function useLoginForm() {
@@ -11,7 +11,8 @@ export function useLoginForm() {
       .string()
       .required("Please input your password")
       .min(6, "Password length must be greater than 6")
-      .max(20, "Password must be no more than 20 characters"),
+      .max(20, "Password must be no more than 20 characters")
+      .matches(/^[^\u4e00-\u9fa5]*$/, "Password cannot contain Chinese characters"),
   });
 
   const { handleSubmit } = useForm<SignupFormValues>({


### PR DESCRIPTION
1. 密码输入框添加快捷查看密码按钮
<img width="392" alt="d23aff4a4a2950c1bb18d2d50a4b418" src="https://github.com/cuixueshe/earthworm/assets/88535417/f15c5c30-331c-4dd6-9403-ec983c24e229">
<img width="371" alt="5d4a6d8cb87f6fde5264efe28a0b11e" src="https://github.com/cuixueshe/earthworm/assets/88535417/41f34af1-2e7c-4a31-9da3-b8931b3bb715">

2. 密码输入框添加校验规则：不能输入中文
<img width="358" alt="972e839c6096a22d405a6fbad84727d" src="https://github.com/cuixueshe/earthworm/assets/88535417/1a6bcf9e-9087-42e2-ad20-7c2d9bceb98e">
