### PR TITLE
feat(client): look password icon support dark and light color

### DIFF
--- a/apps/client/pages/Auth/FormInput.vue
+++ b/apps/client/pages/Auth/FormInput.vue
@@ -20,29 +20,22 @@
       />
 
       <span
-        class="absolute inset-y-0 end-0 grid bottom-1.5 place-content-center px-4 cursor-pointer"
+        class="absolute inset-y-0 end-0 grid bottom-1.5 place-content-center px-4 cursor-pointer text-gray-900 dark:text-gray-300"
         v-if="type === 'password'"
         @click="togglePassword"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="size-4 text-gray-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="size-4" >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
             d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
           />
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-          />
+          <line v-if="inputType === 'password'" x1="22" x2="2" y1="2" y2="22" />
         </svg>
       </span>
       <p class="text-red-500 text-opacity-80 text-xs h-1 m-1">


### PR DESCRIPTION
当前显示密码的icon只有一种暗色，并且没有闭眼的状态，添加支持主题切换变色和闭眼的状态。

<img width="474" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/668205b5-5aad-41bf-908d-ddcace57733e">
<img width="460" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/4003b67f-defc-4d95-8bd9-581d5595bfa0">
<img width="482" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/394ce9a1-b41f-41aa-85a9-a905c1d20c47">
<img width="484" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/d51a9ee8-55f2-4ede-b48f-d5d6d6914ed8">
<img width="463" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/33aeb5b4-5108-456e-906f-48a5083eecfa">
<img width="446" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/3fd1cb02-809f-47db-b4ce-1f50e4d48241">
