### PR TITLE
fix(client): fixed the postion of answer tip in diction mode (close #525)

### DIFF
--- a/apps/client/components/main/AnswerTip.vue
+++ b/apps/client/components/main/AnswerTip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute flex items-center justify-center w-3/4 text-xl top-36 dark:text-gray-50"
+    class="absolute flex items-center justify-center w-3/4 text-xl top-36 left-1/2 translate-x-[-50%] dark:text-gray-50"
   >
     <div class="shadow-xl card bg-base-100">
       <div class="relative card-body">


### PR DESCRIPTION
修复听写模式下答案提示弹窗位置偏移问题。
close #525 

<img width="608" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/8dd27076-0c3d-4437-887d-ed76146d9b64">
<img width="614" alt="image" src="https://github.com/cuixueshe/earthworm/assets/30068682/44f22ea6-5eac-4efe-acb5-2f5b3a6df377">
