### PR TITLE
fix: show question page before switching statements

### DIFF
--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -33,11 +33,14 @@
 <script setup lang="ts">
 import { useVirtualList } from "@vueuse/core";
 import { computed, onMounted } from "vue";
+import { useGameMode } from "~/composables/main/game";
 import { useCourseStore } from "~/store/course";
 import { useContent } from "./useContents";
 
 const coursesStore = useCourseStore();
 const { hideContents, isShowContents, watchClickOutside } = useContent();
+
+const { showQuestion } = useGameMode();
 
 const contentsList = computed(() => {
   return coursesStore.currentCourse?.statements || [];
@@ -69,6 +72,7 @@ function getItemClassNames(index: number) {
 function jumpTo(index: number) {
   hideContents();
   coursesStore.toSpecificStatement(index);
+  showQuestion()  
 }
 </script>
 

--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -38,9 +38,8 @@ import { useCourseStore } from "~/store/course";
 import { useContent } from "./useContents";
 
 const coursesStore = useCourseStore();
-const { hideContents, isShowContents, watchClickOutside } = useContent();
-
 const { showQuestion } = useGameMode();
+const { hideContents, isShowContents, watchClickOutside } = useContent();
 
 const contentsList = computed(() => {
   return coursesStore.currentCourse?.statements || [];
@@ -71,8 +70,8 @@ function getItemClassNames(index: number) {
 
 function jumpTo(index: number) {
   hideContents();
+  showQuestion();
   coursesStore.toSpecificStatement(index);
-  showQuestion()  
 }
 </script>
 


### PR DESCRIPTION
修复显示答案通过目录跳转还会继续下一题答案的问题

修复前
![2024-04-07 7 14 16 PM](https://github.com/cuixueshe/earthworm/assets/103234074/2228caa0-5332-4cdd-b1e8-dc08eeb24b0b)

修复后
![2024-04-07 7 19 11 PM](https://github.com/cuixueshe/earthworm/assets/103234074/b8ecf207-31c1-4587-b28e-3f9e4e5fd17e)

