### PR TITLE
fix: game tips occlusion bug

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
   <header
     :class="[headerClasses]"
-    class="top-0 bg-opacity-50 backdrop-blur-xl z-50 font-customFont px-3 w-full"
+    class="top-0 bg-opacity-50 backdrop-blur-xl z-40 font-customFont px-3 w-full"
   >
     <div class="mx-auto max-w-screen-xl mt-2">
       <div class="flex h-16 items-center justify-between">

--- a/apps/client/components/main/StudyVideoLink.vue
+++ b/apps/client/components/main/StudyVideoLink.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink
     v-if="noteLink"
-    class="tooltip text-xl cursor-pointer fill-current hover:text-[#d946ef]"
+    class="tooltip text-xl cursor-pointer fill-current hover:text-[#d946ef] z-50"
     :data-tip="NOTE_TIP"
     :href="noteLink"
     target="_blank"


### PR DESCRIPTION
修复game页面 tips 遮挡问题

修复前：
<img width="454" alt="a0b8e9a6d275f1d45bfd230e261fb13" src="https://github.com/cuixueshe/earthworm/assets/88535417/07c751f3-f5f4-40e3-aacd-d0c33e8956a1">

修复后：
![image](https://github.com/cuixueshe/earthworm/assets/88535417/e0610b19-e9cf-4e09-97dd-54a6ef527e39)

