### PR TITLE
fix: make navbar long enough

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
   <header
     :class="[headerClasses]"
-    class="top-0 bg-opacity-50 backdrop-blur-xl z-40 font-customFont w-full"
+    class="top-0 bg-opacity-50 backdrop-blur-xl z-40 font-customFont w-[100vw] lg:px-24 xl:px-2 px-7"
   >
     <div class="mx-auto max-w-screen-xl mt-2">
       <div class="flex h-16 items-center justify-between">


### PR DESCRIPTION
navbar长度不够长，在移动端高斯模糊两侧出现缺口，不够美观

以前
<img width="238" alt="image" src="https://github.com/cuixueshe/earthworm/assets/99305540/2b22e379-6d3a-4989-a9b5-e5a7581647bb">

现在
<img width="241" alt="image" src="https://github.com/cuixueshe/earthworm/assets/99305540/f95484a5-f712-496d-9090-5117aee3a633">
