### PR TITLE
style: backTop btn hover  transform change opacity

### DIFF
--- a/apps/client/components/common/backTop.vue
+++ b/apps/client/components/common/backTop.vue
@@ -61,7 +61,7 @@ const scrollToTop = () => {
 .button:hover .svgIcon {
   /* width: 20px; */
   transition-duration: 0.3s;
-  transform: translateY(-200%);
+  opacity: 0;
 }
 
 .button::before {


### PR DESCRIPTION
建议采用opacity，因为有些屏幕下，这个transform的200%可能不准确导致
 #548