### PR TITLE
style: Optimize homepage styling

### DIFF
--- a/apps/client/components/common/Divider.vue
+++ b/apps/client/components/common/Divider.vue
@@ -2,12 +2,12 @@
   <div class="w-full pt-24">
     <span class="relative flex justify-center">
       <div
-        class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent bg-gradient-to-r from-transparent via-gray-500 to-transparent opacity-75"
+          class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent bg-gradient-to-r from-transparent via-gray-500 to-transparent opacity-75"
       ></div>
       <div
-        class="w-8 h-3.5 bg-black rounded-lg absolute -top-2 flex justify-center items-center"
+          class="w-8 h-3.5 bg-gray-600 dark:bg-gray-400 rounded-lg absolute -top-2 flex justify-center items-center"
       >
-        <div class="w-6 bg-white rounded-lg h-2"></div>
+        <div class="w-6 bg-white dark:bg-theme-dark rounded-lg h-2"></div>
       </div>
     </span>
   </div>

--- a/apps/client/components/home/Questions.vue
+++ b/apps/client/components/home/Questions.vue
@@ -10,7 +10,7 @@
         `我们会尽快回复您！`,
       ]"
     />
-    <div class="divide-y divide-gray-800 space-y-4 py-16">
+    <div class="divide-y divide-gray-100 dark:divide-gray-800 py-16">
       <template
         v-for="(qsItem, qsIndex) in QUESTIONS"
         :key="qsIndex"
@@ -43,7 +43,7 @@
             </span>
           </summary>
           <div
-            class="transition-max-height dark:text-gray-500 duration-500 ease-in-out overflow-hidden"
+            class="mb-4 transition-max-height dark:text-gray-500 duration-500 ease-in-out overflow-hidden"
           >
             <template
               v-for="(asItem, asIndex) in qsItem.content"


### PR DESCRIPTION
优化首页样式

常见问题解答区域
1. border颜色优化(适配深色模式)
2. 边距优化(视觉不居中)

优化前
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/ee853c2f-b747-4cef-9639-bff35712ea9f">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/d52cc36d-37bf-4c69-9d45-1be81b63682d">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/862af856-b132-46a7-8a52-42b854126e84">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/060b8f42-e86a-48ad-adae-01cbf6ae3890">

优化后
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/7ed866ab-d250-4d5a-9d74-7edbcf327aaf">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/2a6e8633-025f-47b3-b1bb-f764bdb35657">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/41c3d9ae-ce96-4455-996e-729b6ef04afb">
<img width="300" src="https://github.com/cuixueshe/earthworm/assets/102633566/d5bb4153-f2b0-4fe5-887a-610eff67a321">
