### PR TITLE
fix(DropMenu): add dark mode for Drop Menu Component

### DIFF
--- a/apps/client/components/DropMenu.vue
+++ b/apps/client/components/DropMenu.vue
@@ -28,7 +28,7 @@
       v-if="showDropdown"
       ref="dropdownContainer"
       tabindex="0"
-      class="dropdown-content z-[1] menu p-2 w-52 bg-white border-gray-200 border-2 mt-2 rounded-md"
+      class="dropdown-content z-[1] menu p-2 w-52 bg-white dark:bg-theme-dark border-gray-200 dark:border-gray-600 border-2 mt-2 rounded-md"
     >
       <li
         v-for="(item, index) in showMenuOptions"
@@ -36,7 +36,7 @@
       >
         <span
           @click="item.eventName"
-          class="flex items-center gap-2 rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          class="flex items-center gap-2 rounded-lg  hover:bg-gray-100 dark:hover:bg-secondary hover:text-gray-700  dark:hover:text-white"
         >
           <span v-html="item.icon"></span>
 
@@ -87,7 +87,7 @@ const MENU_OPTIONS = [
     title: "返回游戏",
     name: GO_BACK_GAME_NAME,
     eventName: handleGoBackGamePage,
-    icon: `<svg t="1712760834793" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="4352" width="20" height="20"><path d="M204.896 863.104c-3.456 0-6.912-0.128-10.4-0.416-107.776-8.832-179.584-169.792-163.488-366.4C47.36 296.352 141.024 151.744 249.44 161.056c48.384 3.968 81.92 42.912 105.76 76.416 10.24 14.4 6.88 34.368-7.52 44.64-14.432 10.24-34.368 6.816-44.64-7.552-23.456-32.96-41.6-48.288-58.816-49.728-59.008-4.256-135.584 107.584-149.408 276.672-13.824 169.056 44.192 292.384 104.928 297.344 52.96 4.96 105.024-61.152 132.192-166.848 3.616-14.112 16.352-24 30.976-24h299.904c14.432 0 27.072 9.664 30.88 23.552C722.848 738.24 774.912 803.904 829.024 798.4c29.408-2.976 57.28-33.632 76.448-84.096 22.208-58.592 30.016-135.04 21.888-215.232s-31.072-153.536-64.64-206.56c-28.928-45.696-62.016-70.592-91.744-67.2-18.336 1.888-39.616 19.2-59.808 48.736A31.958 31.958 0 0 1 684.736 288H448c-17.664 0-32-14.336-32-32s14.336-32 32-32h220.48c29.28-37.92 61.568-58.848 96.064-62.336C871.872 150.72 971.136 296.256 991.04 492.672c9.088 89.888-0.032 176.672-25.76 244.384-28.512 75.072-74.592 119.456-129.824 125.056-81.76 8.352-156.128-63.968-196.544-190.08H387.104c-36.48 119.52-104.512 191.072-182.208 191.072zM320 448h-32v-32c0-17.664-14.336-32-32-32s-32 14.336-32 32v32h-32c-17.664 0-32 14.336-32 32s14.336 32 32 32h32v32c0 17.696 14.336 32 32 32s32-14.304 32-32v-32h32c17.664 0 32-14.336 32-32s-14.336-32-32-32z m416-64a2 2 0 1 0 128 0 2 2 0 1 0-128 0zM608 512a2 2 0 1 0 128 0 2 2 0 1 0-128 0z" fill="#8a8a8a" p-id="4353"></path></svg>`,
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="size-5 opacity-75" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 11h4M8 9v4m7-1h.01M18 10h.01m-.69-5H6.68a4 4 0 0 0-3.978 3.59l-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258q-.01-.075-.017-.151A4 4 0 0 0 17.32 5"/></svg>`,
   },
   {
     title: "设置",
@@ -117,28 +117,7 @@ const MENU_OPTIONS = [
     title: "登出",
     name: "logout",
     eventName: handleLogout,
-    icon: `<svg
-        t="1711805258296"
-        class="icon"
-        viewBox="0 0 1024 1024"
-        version="1.1"
-        xmlns="http://www.w3.org/2000/svg"
-        p-id="2307"
-        width="20"
-        height="20"
-        stroke="currentColor"
-      >
-        <path
-          d="M128 514.112c0 21.248 17.216 38.464 38.464 38.464l404.736 0.32-88.064 88.512c-15.04 14.976-15.04 39.36 0 54.4s39.36 14.976 54.4 0l147.712-148.352c2.688-1.536 5.184-3.52 7.488-5.824 7.744-7.744 11.456-17.92 11.264-28.032 0.192-10.112-3.52-20.288-11.264-28.032-2.304-2.24-4.8-4.16-7.488-5.824L537.536 331.264c-15.04-14.976-39.36-14.976-54.4 0-15.04 15.04-15.04 39.424 0 54.464l89.92 90.24L166.464 475.648C145.216 475.648 128 492.864 128 514.112z"
-          fill="#8a8a8a"
-          p-id="2308"
-        ></path>
-        <path
-          d="M213.312 896l597.312 0C857.6 896 896 857.6 896 810.688L896 213.312C896 166.4 857.6 128 810.688 128L213.312 128C165.952 128 128 166.4 128 213.312l0 107.072C128 348.096 146.112 349.632 170.816 358.4c24.64-8.704 42.56-10.176 42.56-37.952L213.376 213.312l597.312 0 0 597.312L213.312 810.624l0-107.136c0-27.712-18.176-29.184-42.816-37.952C145.856 674.368 128 675.776 128 703.552l0 107.136C128 857.6 165.952 896 213.312 896z"
-          fill="#8a8a8a"
-          p-id="2309"
-        ></path>
-      </svg>`,
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="size-5 opacity-75" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4m7 14l5-5l-5-5m5 5H9"/></svg>`,
   },
 ];
 const showMenuOptions = computed(() => {


### PR DESCRIPTION
改动：
- Drop Menu 添加 Dark 样式
- 替换`返回游戏`和`登出`图标，统一风格和样式
![Area_副本](https://github.com/cuixueshe/earthworm/assets/67595284/b1db3cba-ea24-491a-b4d4-c0bc4b18ad22)
