### PR TITLE
chore: integration iconify for TailwindCSS

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "antfu.iconify",
     "antfu.goto-alias",
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,6 +16,8 @@
     "cypress:open": "cypress open"
   },
   "devDependencies": {
+    "@egoist/tailwindcss-icons": "^1.7.4",
+    "@iconify-json/ph": "^1.1.12",
     "@nuxt/test-utils": "^3.10.0",
     "@nuxtjs/tailwindcss": "^6.10.4",
     "@pinia/testing": "^0.1.3",

--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -1,3 +1,8 @@
+const {
+  iconsPlugin,
+  getIconCollections,
+} = require("@egoist/tailwindcss-icons");
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: "class",
@@ -42,5 +47,12 @@ export default {
       },
     },
   },
-  plugins: [require("daisyui")],
+  plugins: [
+    require("daisyui"),
+    iconsPlugin({
+      // 配置需要的 icon 包就行（需要安装）
+      // 来这里找 https://icones.js.org/
+      collections: getIconCollections(["ph"]),
+    }),
+  ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,12 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
+      '@egoist/tailwindcss-icons':
+        specifier: ^1.7.4
+        version: 1.7.4(tailwindcss@3.4.1)
+      '@iconify-json/ph':
+        specifier: ^1.1.12
+        version: 1.1.12
       '@nuxt/test-utils':
         specifier: ^3.10.0
         version: 3.11.0(@vue/test-utils@2.4.4)(h3@1.10.1)(happy-dom@13.3.8)(vite@5.1.0)(vitest@1.2.2)(vue-router@4.2.5)(vue@3.4.15)
@@ -373,6 +379,13 @@ packages:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+    dev: true
+
+  /@antfu/install-pkg@0.1.1:
+    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
+    dependencies:
+      execa: 5.1.1
+      find-up: 5.0.0
     dev: true
 
   /@antfu/utils@0.7.7:
@@ -885,6 +898,17 @@ packages:
     resolution: {integrity: sha512-c5Hkm7MmQC2n5qAsKShjQrHoqlfGslB8+qWzsGGZ+2dHMRTNG60UuzalF0h0rvBax5uzPXuGkYLGaQ+TUX3yMw==}
     dependencies:
       superjson: 2.2.1
+    dev: true
+
+  /@egoist/tailwindcss-icons@1.7.4(tailwindcss@3.4.1):
+    resolution: {integrity: sha512-883qx0sqeNb8km7os0w8K6UYue88dbgTWwyEUwW74Bgz0H7t+m7PMIIEvSQ4JqHwA823Qd5ciz+NoTBWKaMYfg==}
+    peerDependencies:
+      tailwindcss: '*'
+    dependencies:
+      '@iconify/utils': 2.1.22
+      tailwindcss: 3.4.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@electric-sql/pglite@0.1.2:
@@ -1814,6 +1838,30 @@ packages:
   /@hutson/parse-repository-url@5.0.0:
     resolution: {integrity: sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==}
     engines: {node: '>=10.13.0'}
+    dev: true
+
+  /@iconify-json/ph@1.1.12:
+    resolution: {integrity: sha512-m+rXTW084YaQQHT+F8TxdkCoAh+i/5MWRoSuPmxCWPlxwMAaLT/QfyVsbEiV95HM5806U/jKpBV6F1b7Pmr3Vg==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
+  /@iconify/types@2.0.0:
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+    dev: true
+
+  /@iconify/utils@2.1.22:
+    resolution: {integrity: sha512-6UHVzTVXmvO8uS6xFF+L/QTSpTzA/JZxtgU+KYGFyDYMEObZ1bu/b5l+zNJjHy+0leWjHI+C0pXlzGvv3oXZMA==}
+    dependencies:
+      '@antfu/install-pkg': 0.1.1
+      '@antfu/utils': 0.7.7
+      '@iconify/types': 2.0.0
+      debug: 4.3.4(supports-color@8.1.1)
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      mlly: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@img/sharp-darwin-arm64@0.33.2:


### PR DESCRIPTION
## 前言

**目前在项目中并为处理任何 SVG 图标替换，待方案确认集成后，期待小伙伴们的 PR** 😊

在这里 issue 中讨论了下方案：[关于项目中的 SVG 标签影响代码可读性问题](https://github.com/cuixueshe/earthworm/issues/566)

- [Iconify for Tailwind CSS](https://iconify.design/docs/usage/css/tailwind/) - 教你怎么在 tailwind 里面用 iconify
- [Innei/Shiro](https://github.com/Innei/Shiro) - 内神的项目已经很全面了，也是 tailwind + iconify，参考 icon 方案

## Icon 预览网站

- [Icon Sets - Iconify](https://icon-sets.iconify.design/?keyword=twemoji) - iconify 官方的图标检索平台
- [Icônes](https://icones.js.org/) - 托尼写的图标检索平台，体验下来，比官方的好用多了

## [egoist/tailwindcss-icons](https://github.com/egoist/tailwindcss-icons) 方案（选择）

### 优缺点

- **优点**：智能提示很舒服，写法上更偏向 unocss 的使用
- **缺点**：带来的问题就是开销更大，因为它是直接把全部的 `icon` 生成在 `components` 里, 然后再交给 `Tailwind CSS` 从里面进行挑选再输出到我们的 `css` 文件中的，不过问题不大

### 安装依赖

```bash
pnpm add -D @egoist/tailwindcss-icons

# 这里拿 Phosphor Icons 用于示例，正好项目中也有需要用到的
pnpm add -D @iconify-json/ph
```

### 配置 tailwind.config.js 文件

```js
const {
  iconsPlugin,
  getIconCollections,
} = require("@egoist/tailwindcss-icons");

export default {
  plugins: [
    iconsPlugin({
      // 配置需要的 icon 包就行（需要安装）
      collections: getIconCollections(["mdi", "lucide"]),
    }),
  ],
}
```


### 使用示例

```html
<!-- pattern: i-{collection_name}-{icon_name} -->
<span class="i-mdi-home"></span>
```

在 IDE 中真实使用体验

![1712993190364.png](https://cdn.jsdelivr.net/gh/fengstats/blogcdn@main/2024/1712993190364.png)

## [iconify/iconify](https://github.com/iconify/iconify/tree/main/plugins/tailwind) 方案（舍弃）

### 优缺点

- **优点**：基于 `JIT` 动态加载生成，开发时开销更小
- **缺点**：写法有点恶心 + 没有提示

```bash
pnpm add -D @iconify/tailwind
```

### 配置 tailwind.config.js 文件

```js
const { addDynamicIconSelectors } = require("@iconify/tailwind");

export default {
  plugins: [addDynamicIconSelectors()],
}
```

### 使用示例

```html
<span class="icon-[mdi-light--home]"></span>
```