### PR TITLE
fix: poster qrcode variation bug

### DIFF
--- a/apps/client/composables/main/shareImage/imageTemplates/tpl_2.ts
+++ b/apps/client/composables/main/shareImage/imageTemplates/tpl_2.ts
@@ -102,7 +102,7 @@ export const tpl_2 = ({
                   {
                     type: "img",
                     props: {
-                      tw: "w-12 h-12 p-0 m-0",
+                      tw: "w-12 h-13 p-0 m-0 flex-shirk-0",
                       src: "/qrcode.png",
                     },
                   },


### PR DESCRIPTION
-	修复第二张海报图片qrcode变形问题（目前大多数用户都使用第二张海报打卡）
	之前:
	<img width="244" alt="07b73fc0797ff51883024c6e03b39fa" src="https://github.com/cuixueshe/earthworm/assets/88535417/4af7b9b0-0c4f-4408-a8f8-f0161c99aea4">

	之后：
	<img width="244" alt="07b73fc0797ff51883024c6e03b39fa" src="https://github.com/cuixueshe/earthworm/assets/88535417/6b3f9dad-02d4-4b41-90f5-91f87baeec4b">
