### PR TITLE
Feat/add calendar 使用 echarts 配置日历对象

### DIFF
--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -1,4 +1,5 @@
 <template>
+<<<<<<< Updated upstream
   <header
     :class="isStickyNavBar"
     class="w-full top-0 bg-opacity-50 backdrop-blur-xl font-customFont z-40"
@@ -117,13 +118,129 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+=======
+  <nav class="flex items-center justify-between h-20 shrink-0">
+    <NuxtLink to="/">
+      <div class="flex items-center logo">
+        <img
+          width="48"
+          height="48"
+          class="mr-6 overflow-hidden rounded-md"
+          src="/logo.png"
+          alt="earth-worm-logo"
+        />
+        <h1
+          class="text-2xl font-black leading-none leading-normal text-wrap text-fuchsia-400"
+        >
+          Earthworm
+        </h1>
+      </div>
+    </NuxtLink>
+    <div class="flex items-center">
+      <button
+        v-if="!userStore.user && route.name !== 'Auth-Login'"
+        class="h-8 px-2 mx-1 btn btn-sm btn-ghost"
+        @click="handleLogin"
+      >
+        Log in
+      </button>
+      <button
+        v-else-if="!userStore.user && route.name !== 'Auth-Signup'"
+        class="h-8 px-2 mx-1 btn btn-sm btn-ghost"
+        @click="handleSignup"
+      >
+        Sign up
+      </button>
+      <div v-else class="dropdown dropdown-end">
+        <button
+          tabindex="0"
+          class="w-8 h-8 p-0 mx-1 rounded-md btn btn-sm btn-ghost"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-6 h-6"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+            />
+          </svg>
+        </button>
+        <ul
+          tabindex="0"
+          class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-32"
+        >
+          <li @click="handleViewUserInfo"><a>User info</a></li>
+          <li @click="handleLogout"><a>Log out</a></li>
+          <!-- <li><a>Item 2</a></li> -->
+        </ul>
+      </div>
+      <button
+        class="w-8 h-8 p-0 mx-1 rounded-md btn btn-sm btn-ghost"
+        @click="toggleDarkMode"
+      >
+        <svg
+          v-if="isDarkMode"
+          xmlns="http://www.w3.org/2000/svg"
+          width="1.5em"
+          height="1.5em"
+          viewBox="0 0 256 256"
+        >
+          <path
+            fill="currentColor"
+            d="M233.54 142.23a8 8 0 0 0-8-2a88.08 88.08 0 0 1-109.8-109.8a8 8 0 0 0-10-10a104.84 104.84 0 0 0-52.91 37A104 104 0 0 0 136 224a103.09 103.09 0 0 0 62.52-20.88a104.84 104.84 0 0 0 37-52.91a8 8 0 0 0-1.98-7.98m-44.64 48.11A88 88 0 0 1 65.66 67.11a89 89 0 0 1 31.4-26A106 106 0 0 0 96 56a104.11 104.11 0 0 0 104 104a106 106 0 0 0 14.92-1.06a89 89 0 0 1-26.02 31.4"
+          />
+        </svg>
+        <svg
+          v-else
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-6 h-6"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+          />
+        </svg>
+      </button>
+    </div>
+    <MessageBox
+      v-model:isShowModal="isShowModal"
+      title="Notice"
+      content="Are you sure to exit?"
+      @confirm="handleLogoutConfirm"
+    />
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useMessage } from "naive-ui";
+import { navigateTo } from "nuxt/app";
+>>>>>>> Stashed changes
 import { useRoute } from "vue-router";
 import { Theme, useDarkMode } from "~/composables/darkMode";
 import { isAuthenticated, signIn, signOut } from "~/services/auth";
 import { useUserStore } from "~/store/user";
+<<<<<<< Updated upstream
+=======
+import { cleanToken } from "~/utils/token";
+import { computed } from "vue";
+import { useCalendarStore } from "~/store/calendar";
+>>>>>>> Stashed changes
 
 const route = useRoute();
 const userStore = useUserStore();
+<<<<<<< Updated upstream
 const { darkMode, toggleDarkMode } = useDarkMode();
 
 const isShowModal = ref(false);
@@ -142,8 +259,48 @@ const isStickyNavBar = computed(() => {
   }
   return "";
 });
+=======
+const calendarStore = useCalendarStore();
+
+const isShowModal = ref(false);
+
+const { setDarkMode, toggleDarkMode, darkMode } = useDarkMode();
+
+const isDarkMode = computed(() => darkMode.value === Theme.DARK);
+
+const handleViewUserInfo = () => {
+  navigateTo("/user/info");
+};
+
+const handleLogin = () => {
+  navigateTo("/auth/login");
+};
+
+const handleSignup = () => {
+  navigateTo("/auth/signup");
+};
+
+const message = useMessage();
+>>>>>>> Stashed changes
 
 const handleLogout = () => {
   isShowModal.value = true;
 };
+<<<<<<< Updated upstream
 </script>
+=======
+
+const handleLogoutConfirm = () => {
+  userStore.logoutUser();
+  calendarStore.logoutCalendar();
+  cleanToken();
+  message.success("logout success", {
+    duration: 500,
+    onLeave() {
+      navigateTo("/");
+    },
+  });
+};
+</script>
+<style></style>
+>>>>>>> Stashed changes

--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -1,14 +1,13 @@
 <template>
-<<<<<<< Updated upstream
   <header
     :class="isStickyNavBar"
-    class="w-full top-0 bg-opacity-50 backdrop-blur-xl font-customFont z-40"
+    class="top-0 z-40 w-full bg-opacity-50 backdrop-blur-xl font-customFont"
   >
-    <div class="mx-auto max-w-screen-xl px-6">
-      <div class="flex h-16 items-center justify-between">
-        <div class="flex flex-1 items-center justify-between">
+    <div class="max-w-screen-xl px-6 mx-auto">
+      <div class="flex items-center justify-between h-16">
+        <div class="flex items-center justify-between flex-1">
           <NuxtLink to="/">
-            <div class="logo flex items-center">
+            <div class="flex items-center logo">
               <img
                 width="48"
                 height="48"
@@ -51,7 +50,7 @@
           <!-- 显示用户信息 -->
           <div
             v-if="isAuthenticated()"
-            class="logged-in flex items-center"
+            class="flex items-center logged-in"
           >
             <div
               class="mx-2 font-500 truncate min-[500px]:max-w-[6em] max-w-[4em]"
@@ -66,14 +65,14 @@
             v-else
             @click="signIn()"
             aria-label="Login"
-            class="btn btn-sm btn-ghost text-base font-normal dark:text-white rounded-md mx-1 h-8 px-4"
+            class="h-8 px-4 mx-1 text-base font-normal rounded-md btn btn-sm btn-ghost dark:text-white"
           >
             <span class="relative">登录</span>
           </button>
 
           <!-- 切换主题 -->
           <button
-            class="btn btn-sm btn-ghost rounded-md mx-1 w-8 h-8 p-0"
+            class="w-8 h-8 p-0 mx-1 rounded-md btn btn-sm btn-ghost"
             @click="toggleDarkMode"
           >
             <svg
@@ -112,135 +111,20 @@
     v-model:isShowModal="isShowModal"
     title="提示"
     content="是否确认退出登录？"
-    @confirm="signOut()"
+    @confirm="handleSignOut()"
   />
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-=======
-  <nav class="flex items-center justify-between h-20 shrink-0">
-    <NuxtLink to="/">
-      <div class="flex items-center logo">
-        <img
-          width="48"
-          height="48"
-          class="mr-6 overflow-hidden rounded-md"
-          src="/logo.png"
-          alt="earth-worm-logo"
-        />
-        <h1
-          class="text-2xl font-black leading-none leading-normal text-wrap text-fuchsia-400"
-        >
-          Earthworm
-        </h1>
-      </div>
-    </NuxtLink>
-    <div class="flex items-center">
-      <button
-        v-if="!userStore.user && route.name !== 'Auth-Login'"
-        class="h-8 px-2 mx-1 btn btn-sm btn-ghost"
-        @click="handleLogin"
-      >
-        Log in
-      </button>
-      <button
-        v-else-if="!userStore.user && route.name !== 'Auth-Signup'"
-        class="h-8 px-2 mx-1 btn btn-sm btn-ghost"
-        @click="handleSignup"
-      >
-        Sign up
-      </button>
-      <div v-else class="dropdown dropdown-end">
-        <button
-          tabindex="0"
-          class="w-8 h-8 p-0 mx-1 rounded-md btn btn-sm btn-ghost"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke="currentColor"
-            class="w-6 h-6"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
-            />
-          </svg>
-        </button>
-        <ul
-          tabindex="0"
-          class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-32"
-        >
-          <li @click="handleViewUserInfo"><a>User info</a></li>
-          <li @click="handleLogout"><a>Log out</a></li>
-          <!-- <li><a>Item 2</a></li> -->
-        </ul>
-      </div>
-      <button
-        class="w-8 h-8 p-0 mx-1 rounded-md btn btn-sm btn-ghost"
-        @click="toggleDarkMode"
-      >
-        <svg
-          v-if="isDarkMode"
-          xmlns="http://www.w3.org/2000/svg"
-          width="1.5em"
-          height="1.5em"
-          viewBox="0 0 256 256"
-        >
-          <path
-            fill="currentColor"
-            d="M233.54 142.23a8 8 0 0 0-8-2a88.08 88.08 0 0 1-109.8-109.8a8 8 0 0 0-10-10a104.84 104.84 0 0 0-52.91 37A104 104 0 0 0 136 224a103.09 103.09 0 0 0 62.52-20.88a104.84 104.84 0 0 0 37-52.91a8 8 0 0 0-1.98-7.98m-44.64 48.11A88 88 0 0 1 65.66 67.11a89 89 0 0 1 31.4-26A106 106 0 0 0 96 56a104.11 104.11 0 0 0 104 104a106 106 0 0 0 14.92-1.06a89 89 0 0 1-26.02 31.4"
-          />
-        </svg>
-        <svg
-          v-else
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="w-6 h-6"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-          />
-        </svg>
-      </button>
-    </div>
-    <MessageBox
-      v-model:isShowModal="isShowModal"
-      title="Notice"
-      content="Are you sure to exit?"
-      @confirm="handleLogoutConfirm"
-    />
-  </nav>
-</template>
-
-<script setup lang="ts">
-import { ref } from "vue";
-import { useMessage } from "naive-ui";
-import { navigateTo } from "nuxt/app";
->>>>>>> Stashed changes
 import { useRoute } from "vue-router";
 import { Theme, useDarkMode } from "~/composables/darkMode";
 import { isAuthenticated, signIn, signOut } from "~/services/auth";
-import { useUserStore } from "~/store/user";
-<<<<<<< Updated upstream
-=======
-import { cleanToken } from "~/utils/token";
-import { computed } from "vue";
 import { useCalendarStore } from "~/store/calendar";
->>>>>>> Stashed changes
+import { useUserStore } from "~/store/user";
 
 const route = useRoute();
 const userStore = useUserStore();
-<<<<<<< Updated upstream
 const { darkMode, toggleDarkMode } = useDarkMode();
 
 const isShowModal = ref(false);
@@ -259,48 +143,13 @@ const isStickyNavBar = computed(() => {
   }
   return "";
 });
-=======
-const calendarStore = useCalendarStore();
-
-const isShowModal = ref(false);
-
-const { setDarkMode, toggleDarkMode, darkMode } = useDarkMode();
-
-const isDarkMode = computed(() => darkMode.value === Theme.DARK);
-
-const handleViewUserInfo = () => {
-  navigateTo("/user/info");
-};
-
-const handleLogin = () => {
-  navigateTo("/auth/login");
-};
-
-const handleSignup = () => {
-  navigateTo("/auth/signup");
-};
-
-const message = useMessage();
->>>>>>> Stashed changes
 
 const handleLogout = () => {
   isShowModal.value = true;
 };
-<<<<<<< Updated upstream
-</script>
-=======
-
-const handleLogoutConfirm = () => {
-  userStore.logoutUser();
+const handleSignOut = () => {
+  signOut();
+  const calendarStore = useCalendarStore();
   calendarStore.logoutCalendar();
-  cleanToken();
-  message.success("logout success", {
-    duration: 500,
-    onLeave() {
-      navigateTo("/");
-    },
-  });
 };
 </script>
-<style></style>
->>>>>>> Stashed changes

--- a/apps/client/components/main/Answer.vue
+++ b/apps/client/components/main/Answer.vue
@@ -3,11 +3,7 @@
     <div class="ml-8 text-5xl text-fuchsia-500 dark:text-gray-50">
       {{ courseStore.currentStatement?.english }}
       <svg
-<<<<<<< Updated upstream
         class="inline-block ml-1 cursor-pointer w-7 h-7 fill-gray-500 hover:fill-fuchsia-500"
-=======
-        class="inline-block ml-1 cursor-pointer w-7 h-7"
->>>>>>> Stashed changes
         viewBox="0 0 1024 1024"
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
@@ -15,10 +11,6 @@
       >
         <path
           d="M342.4 384H128v256h214.4L576 826.8V197.2L342.4 384zM64 320h256L640 64v896L320 704H64V320z m640 256h256v-64H704v64z m16.8 159.5l181 181 45.3-45.3-181-181-45.3 45.3z m33.9-343.9l181-181-45.3-45.3-181 181 45.3 45.3z"
-<<<<<<< Updated upstream
-=======
-          fill="#666666"
->>>>>>> Stashed changes
         ></path>
       </svg>
     </div>
@@ -48,26 +40,18 @@ import { onMounted, onUnmounted } from "vue";
 import { useCurrentStatementEnglishSound } from "~/composables/main/englishSound";
 import { useGameMode } from "~/composables/main/game";
 import { useSummary } from "~/composables/main/summary";
-<<<<<<< Updated upstream
 import { useAutoPronunciation } from "~/composables/user/sound";
+import { useCalendarStore } from "~/store/calendar";
 import { useCourseStore } from "~/store/course";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
-=======
-import { useAutoSound } from "~/composables/user/sound";
-import { useCalendarStore } from "~/store/calendar";
->>>>>>> Stashed changes
 
 const courseStore = useCourseStore();
 const { handlePlaySound } = usePlayEnglishSound();
 const { showSummary } = useSummary();
 const { showQuestion } = useGameMode();
-<<<<<<< Updated upstream
 const { isAutoPlaySound } = useAutoPronunciation();
 
 registerShortcutKeyForNextQuestion();
-=======
-const { isAutoPlaySound } = useAutoSound();
->>>>>>> Stashed changes
 
 function usePlayEnglishSound() {
   const { playSound } = useCurrentStatementEnglishSound();

--- a/apps/client/components/main/Answer.vue
+++ b/apps/client/components/main/Answer.vue
@@ -3,7 +3,11 @@
     <div class="ml-8 text-5xl text-fuchsia-500 dark:text-gray-50">
       {{ courseStore.currentStatement?.english }}
       <svg
+<<<<<<< Updated upstream
         class="inline-block ml-1 cursor-pointer w-7 h-7 fill-gray-500 hover:fill-fuchsia-500"
+=======
+        class="inline-block ml-1 cursor-pointer w-7 h-7"
+>>>>>>> Stashed changes
         viewBox="0 0 1024 1024"
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
@@ -11,6 +15,10 @@
       >
         <path
           d="M342.4 384H128v256h214.4L576 826.8V197.2L342.4 384zM64 320h256L640 64v896L320 704H64V320z m640 256h256v-64H704v64z m16.8 159.5l181 181 45.3-45.3-181-181-45.3 45.3z m33.9-343.9l181-181-45.3-45.3-181 181 45.3 45.3z"
+<<<<<<< Updated upstream
+=======
+          fill="#666666"
+>>>>>>> Stashed changes
         ></path>
       </svg>
     </div>
@@ -40,17 +48,26 @@ import { onMounted, onUnmounted } from "vue";
 import { useCurrentStatementEnglishSound } from "~/composables/main/englishSound";
 import { useGameMode } from "~/composables/main/game";
 import { useSummary } from "~/composables/main/summary";
+<<<<<<< Updated upstream
 import { useAutoPronunciation } from "~/composables/user/sound";
 import { useCourseStore } from "~/store/course";
 import { cancelShortcut, registerShortcut } from "~/utils/keyboardShortcuts";
+=======
+import { useAutoSound } from "~/composables/user/sound";
+import { useCalendarStore } from "~/store/calendar";
+>>>>>>> Stashed changes
 
 const courseStore = useCourseStore();
 const { handlePlaySound } = usePlayEnglishSound();
 const { showSummary } = useSummary();
 const { showQuestion } = useGameMode();
+<<<<<<< Updated upstream
 const { isAutoPlaySound } = useAutoPronunciation();
 
 registerShortcutKeyForNextQuestion();
+=======
+const { isAutoPlaySound } = useAutoSound();
+>>>>>>> Stashed changes
 
 function usePlayEnglishSound() {
   const { playSound } = useCurrentStatementEnglishSound();
@@ -87,7 +104,17 @@ function registerShortcutKeyForNextQuestion() {
 }
 
 function goToNextQuestion() {
-  if (courseStore.isAllDone()) {
+  if (courseStore.isAllDone() || true) {
+    // 奉新当前日历
+    const calendarStore = useCalendarStore();
+    const date = new Date();
+    calendarStore.updateCalendarInfo(
+      `${date.getFullYear()}-${
+        date.getMonth() + 1 < 10
+          ? "0" + (date.getMonth() + 1)
+          : date.getMonth() + 1
+      }-${date.getDate()}`
+    );
     showSummary();
     return;
   }

--- a/apps/client/components/main/Answer.vue
+++ b/apps/client/components/main/Answer.vue
@@ -104,7 +104,7 @@ function registerShortcutKeyForNextQuestion() {
 }
 
 function goToNextQuestion() {
-  if (courseStore.isAllDone() || true) {
+  if (courseStore.isAllDone()) {
     // 奉新当前日历
     const calendarStore = useCalendarStore();
     const date = new Date();

--- a/apps/client/components/user/Home.vue
+++ b/apps/client/components/user/Home.vue
@@ -1,14 +1,138 @@
 <template>
-  <div>TODO</div>
+  <!-- <div>TODO</div>
   <div>for instance</div>
   <div>
     打卡模块
     <a href="https://github.com/cuixueshe/earthworm/issues/1"
       >(from Issues #1)</a
     >
-  </div>
+  </div> -->
+  <div>打卡模块</div>
+  <div class="w-full main h-96" id="main"></div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { onMounted } from "vue";
+import * as Echarts from "echarts";
+import { useCalendarStore, LOCAL_STORAGE_KEY } from "~/store/calendar";
+import { string } from "yup";
+
+interface calendarOptions {
+  title: {
+    top?: number;
+    left?: string;
+    text: string;
+  };
+  tooltip: {};
+  visualMap: {};
+  calendar: {};
+  series: {};
+}
+
+let calendarChart = null;
+let calendarOpts: calendarOptions = {} as calendarOptions;
+
+// 初始化日历选项
+function initChartOpts() {
+  const calendarStore = useCalendarStore();
+  const { getCalendarInfo, initCalendar } = calendarStore;
+  console.log("getCalendarInfo", getCalendarInfo());
+  if (!getCalendarInfo()) initCalendar();
+  calendarOpts = {
+    title: {
+      top: 30,
+      left: "center",
+      text: "Earthworm Calendar",
+    },
+    visualMap: {
+      min: 0,
+      max: 20,
+      type: "piecewise",
+      orient: "horizontal",
+      left: "center",
+      top: 65,
+      color: [
+        "rgb(33, 110, 57)",
+        "rgb(48, 161, 78)",
+        "rgb(64, 196, 99)",
+        "rgb(155, 233, 168)",
+        "rgb(235, 237, 240)",
+      ],
+    },
+    tooltip: {
+      show: true,
+      valueFormatter: (value: string) => {
+        return value;
+      },
+    },
+    calendar: {
+      top: 120,
+      left: 60,
+      right: 30,
+      cellSize: [12, 17],
+      border: "transparent",
+      range: "2024",
+      itemStyle: {
+        borderWidth: 5,
+        borderColor: "transparent",
+        borderCap: "square",
+        color: "#fff",
+      },
+      splitLine: {
+        show: false,
+      },
+      monthLabel: {
+        show: true,
+        color: "#000",
+        formatter: function (param: { MM: String }) {
+          const obj = {
+            "01": "Jan",
+            "02": "Feb",
+            "03": "Mar",
+            "04": "Apr",
+            "05": "May",
+            "06": "Jun",
+            "07": "Jul",
+            "08": "Aug",
+            "09": "Sep",
+            10: "Oct",
+            11: "Nov",
+            12: "Dec",
+          };
+          return obj[param.MM];
+        },
+      },
+      dayLabel: { show: true, nameMap: ["Mon", "", "Wed", "", "Fri", "", ""] },
+      yearLabel: { show: false, margin: "40" },
+    },
+    series: {
+      type: "heatmap",
+      coordinateSystem: "calendar",
+      data: Array.from(getCalendarInfo()),
+    },
+  };
+}
+function initCalendar() {
+  initChartOpts();
+  const calendarDom = document.getElementById("main");
+  calendarChart = Echarts.init(calendarDom);
+  calendarChart.setOption(calendarOpts);
+}
+
+window.addEventListener("storage", (e) => {
+  if (e.key === LOCAL_STORAGE_KEY) {
+    if (calendarChart) {
+      initChartOpts();
+      calendarChart.setOption(calendarOpts);
+    } else {
+      initCalendar();
+    }
+  }
+});
+
+onMounted(() => {
+  initCalendar();
+});
+</script>
 
 <style lang="scss" scoped></style>

--- a/apps/client/components/user/Home.vue
+++ b/apps/client/components/user/Home.vue
@@ -8,14 +8,16 @@
     >
   </div> -->
   <div>打卡模块</div>
-  <div class="w-full main h-96" id="main"></div>
+  <div
+    class="w-full main h-96"
+    id="main"
+  ></div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from "vue";
 import * as Echarts from "echarts";
-import { useCalendarStore, LOCAL_STORAGE_KEY } from "~/store/calendar";
-import { string } from "yup";
+import { onMounted } from "vue";
+import { LOCAL_STORAGE_KEY, useCalendarStore } from "~/store/calendar";
 
 interface calendarOptions {
   title: {
@@ -36,7 +38,6 @@ let calendarOpts: calendarOptions = {} as calendarOptions;
 function initChartOpts() {
   const calendarStore = useCalendarStore();
   const { getCalendarInfo, initCalendar } = calendarStore;
-  console.log("getCalendarInfo", getCalendarInfo());
   if (!getCalendarInfo()) initCalendar();
   calendarOpts = {
     title: {
@@ -61,8 +62,18 @@ function initChartOpts() {
     },
     tooltip: {
       show: true,
-      valueFormatter: (value: string) => {
-        return value;
+      position: "top",
+      backgroundColor: "#000",
+      borderColor: "transparent",
+      textStyle: {
+        color: "#fff",
+      },
+      formatter: function (params: {
+        value: [string, number];
+        [key: string]: any;
+      }) {
+        const { value } = params;
+        return `${value[1]} completed on ${value[0]}`;
       },
     },
     calendar: {
@@ -102,8 +113,9 @@ function initChartOpts() {
           return obj[param.MM];
         },
       },
-      dayLabel: { show: true, nameMap: ["Mon", "", "Wed", "", "Fri", "", ""] },
-      yearLabel: { show: false, margin: "40" },
+      // dayLabel: { show: true, nameMap: ["Mon", "", "Wed", "", "Fri", "", ""] },
+      dayLabel: { show: true, nameMap: ["M", "", "W", "", "F", "", ""] },
+      yearLabel: { show: true, margin: "38" },
     },
     series: {
       type: "heatmap",

--- a/apps/client/components/user/Home.vue
+++ b/apps/client/components/user/Home.vue
@@ -69,6 +69,13 @@ function initChartOpts() {
       orient: "horizontal",
       left: "center",
       top: 65,
+      pieces: [
+        { min: 10 },
+        { min: 5, max: 10 },
+        { min: 3, max: 5 },
+        { min: 1, max: 3 },
+        { min: 0, max: 0 },
+      ],
       color: [
         "rgb(33, 110, 57)",
         "rgb(48, 161, 78)",

--- a/apps/client/components/user/Home.vue
+++ b/apps/client/components/user/Home.vue
@@ -15,9 +15,26 @@
 </template>
 
 <script setup lang="ts">
-import * as Echarts from "echarts";
+import { HeatmapChart } from "echarts/charts";
+import {
+  CalendarComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
 import { onMounted } from "vue";
 import { LOCAL_STORAGE_KEY, useCalendarStore } from "~/store/calendar";
+
+echarts.use([
+  TitleComponent,
+  CalendarComponent,
+  TooltipComponent,
+  VisualMapComponent,
+  HeatmapChart,
+  CanvasRenderer,
+]);
 
 interface calendarOptions {
   title: {
@@ -47,7 +64,7 @@ function initChartOpts() {
     },
     visualMap: {
       min: 0,
-      max: 20,
+      max: 15,
       type: "piecewise",
       orient: "horizontal",
       left: "center",
@@ -127,7 +144,7 @@ function initChartOpts() {
 function initCalendar() {
   initChartOpts();
   const calendarDom = document.getElementById("main");
-  calendarChart = Echarts.init(calendarDom);
+  calendarChart = echarts.init(calendarDom);
   calendarChart.setOption(calendarOpts);
 }
 

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -42,9 +42,13 @@
     "@types/country-telephone-data": "^0.6.3",
     "axios": "^1.6.6",
     "canvas-confetti": "^1.9.2",
+<<<<<<< Updated upstream
     "country-telephone-data": "^0.6.3",
     "dayjs": "^1.11.10",
     "google-libphonenumber": "^3.2.34",
+=======
+    "echarts": "^5.5.0",
+>>>>>>> Stashed changes
     "pinia": "^2.1.7",
     "satori": "^0.10.13",
     "vee-validate": "^4.12.5",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -42,13 +42,10 @@
     "@types/country-telephone-data": "^0.6.3",
     "axios": "^1.6.6",
     "canvas-confetti": "^1.9.2",
-<<<<<<< Updated upstream
     "country-telephone-data": "^0.6.3",
     "dayjs": "^1.11.10",
     "google-libphonenumber": "^3.2.34",
-=======
     "echarts": "^5.5.0",
->>>>>>> Stashed changes
     "pinia": "^2.1.7",
     "satori": "^0.10.13",
     "vee-validate": "^4.12.5",

--- a/apps/client/store/calendar.ts
+++ b/apps/client/store/calendar.ts
@@ -1,0 +1,105 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import * as Echarts from "echarts";
+
+export const LOCAL_STORAGE_KEY = "calendarInfo";
+export const LOCAL_CALENDAR_KEY_INDEX = "dayForIndexMap";
+
+type dayForIndexMapType = {
+  [key: string]: any;
+};
+
+// [[day: index]]
+let dayForIndexMap: dayForIndexMapType = {};
+
+// 获取某一年的日历数据
+function getCalendarDataByYear(year: String) {
+  const date = +Echarts.time.parse(year + "-01-01");
+  const end = +Echarts.time.parse(+year + 1 + "-01-01");
+  const dayTime = 3600 * 24 * 1000;
+  const data = [];
+  for (let time = date, index = 0; time < end; time += dayTime, index++) {
+    const day = Echarts.time.format(time, "{yyyy}-{MM}-{dd}", false);
+    dayForIndexMap[day] = index;
+    data.push([day, 0]);
+  }
+  return data;
+}
+
+type Calendar = Array<[string, number]>;
+
+export const useCalendarStore = defineStore("calendar", () => {
+  const calendar = ref<Calendar>();
+
+  // 初始化
+  function initCalendar() {
+    calendar.value = getCalendarInfo() || getCalendarDataByYear("2024");
+    saveCalendarInfo();
+    saveCalendarKey();
+  }
+
+  // 更新
+  function updateCalendarInfo(time: string) {
+    dayForIndexMap = getCalendarKeyInfo();
+    restoreCalendar();
+    const index = dayForIndexMap[time];
+    if (calendar.value && calendar.value[index]) {
+      calendar.value[index] = [
+        calendar.value[index][0],
+        Number(calendar.value[index][1]) + 5,
+      ];
+      saveCalendarInfo();
+    }
+  }
+
+  // 登出清空
+  function logoutCalendar() {
+    calendar.value = undefined;
+    removeCalendarInfo();
+  }
+
+  // 设置日历数据
+  function saveCalendarInfo() {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(calendar.value));
+  }
+
+  // 设置 {day: index}
+  function saveCalendarKey() {
+    localStorage.setItem(
+      LOCAL_CALENDAR_KEY_INDEX,
+      JSON.stringify(dayForIndexMap)
+    );
+  }
+
+  // 清除日历缓存
+  function removeCalendarInfo() {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+  }
+
+  // 获取日历数据
+  function getCalendarInfo() {
+    const data = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return data ? JSON.parse(data) : null;
+  }
+
+  // 获取 {day: index}
+  function getCalendarKeyInfo() {
+    const data = localStorage.getItem(LOCAL_CALENDAR_KEY_INDEX);
+    return data ? JSON.parse(data) : null;
+  }
+
+  // 重新赋值 calendar
+  function restoreCalendar() {
+    const userInfoStringify = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (userInfoStringify) calendar.value = JSON.parse(userInfoStringify);
+  }
+
+  return {
+    calendar,
+    initCalendar,
+    logoutCalendar,
+    restoreCalendar,
+    getCalendarInfo,
+    updateCalendarInfo,
+  };
+});

--- a/apps/client/store/calendar.ts
+++ b/apps/client/store/calendar.ts
@@ -1,6 +1,6 @@
+import * as Echarts from "echarts";
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import * as Echarts from "echarts";
 
 export const LOCAL_STORAGE_KEY = "calendarInfo";
 export const LOCAL_CALENDAR_KEY_INDEX = "dayForIndexMap";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,6 @@ importers:
       canvas-confetti:
         specifier: ^1.9.2
         version: 1.9.2
-<<<<<<< Updated upstream
       country-telephone-data:
         specifier: ^0.6.3
         version: 0.6.3
@@ -209,11 +208,9 @@ importers:
       google-libphonenumber:
         specifier: ^3.2.34
         version: 3.2.34
-=======
       echarts:
         specifier: ^5.5.0
         version: 5.5.0
->>>>>>> Stashed changes
       pinia:
         specifier: ^2.1.7
         version: 2.1.7(typescript@5.3.3)(vue@3.4.15)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,7 @@ importers:
       canvas-confetti:
         specifier: ^1.9.2
         version: 1.9.2
+<<<<<<< Updated upstream
       country-telephone-data:
         specifier: ^0.6.3
         version: 0.6.3
@@ -208,6 +209,11 @@ importers:
       google-libphonenumber:
         specifier: ^3.2.34
         version: 3.2.34
+=======
+      echarts:
+        specifier: ^5.5.0
+        version: 5.5.0
+>>>>>>> Stashed changes
       pinia:
         specifier: ^2.1.7
         version: 2.1.7(typescript@5.3.3)(vue@3.4.15)
@@ -6757,6 +6763,13 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
+  /echarts@5.5.0:
+    resolution: {integrity: sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==}
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.5.0
+    dev: false
+
   /editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
     engines: {node: '>=14'}
@@ -10115,6 +10128,7 @@ packages:
 
   /napi-wasm@1.1.0:
     resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    requiresBuild: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -12991,6 +13005,10 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+    dev: false
+
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     requiresBuild: true
@@ -14215,3 +14233,9 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  /zrender@5.5.0:
+    resolution: {integrity: sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==}
+    dependencies:
+      tslib: 2.3.0
+    dev: false


### PR DESCRIPTION
1、引入 Echarts 日历，示例：https://echarts.apache.org/examples/zh/editor.html?c=calendar-heatmap
2、在个人信息模块新增日历，在 onMounted 中初始化日历配置项、初始数据并初始化 DOM
3、pinia 新增 calendar 模块，维护日历初始化、更新、卸载等操作
4、在完成每一课后更新日历数据
5、在日历模块监听 storage 改动，如果 key === ‘calendarInfo’ 执行日历样式更新
6、登出之后会 removeItem 日历数据，重新登录会再次初始化