### PR TITLE
fix: rank empty username bug

### DIFF
--- a/apps/client/components/rank/RankingItem.vue
+++ b/apps/client/components/rank/RankingItem.vue
@@ -6,7 +6,7 @@
       class="w-16"
       :rank="rank"
     />
-    <div class="flex-1 truncate text-center">{{ username }}</div>
+    <div class="flex-1 truncate text-center">{{ username || "匿名" }}</div>
     <div class="w-16 text-right">{{ count }} 课</div>
   </div>
 </template>


### PR DESCRIPTION
之前：
![image](https://github.com/cuixueshe/earthworm/assets/88535417/533eb5ca-ea36-4b2c-bd7d-76c42d3b8ec9)
之后：
![image](https://github.com/cuixueshe/earthworm/assets/88535417/15336935-dffe-4251-9717-78d6fb01812f)