### PR TITLE
fix: misaligned style of 'Start Earthworm' button

### DIFF
--- a/apps/client/components/Landing/Banner.vue
+++ b/apps/client/components/Landing/Banner.vue
@@ -31,7 +31,7 @@
     <div class="my-10 flex flex-wrap items-center justify-center gap-4 font-customFont">
       <button
         @click="handleKeydown"
-        class="btn"
+        class="btn relative"
         type="button"
       >
         <strong>开启Earthworm</strong>


### PR DESCRIPTION
暂时解决问题，应该和z-index的层级关系有关，可以考虑后期重构样式的部分到tailwindCSS