### PR TITLE
fix: update margin value for summary page

### DIFF
--- a/apps/client/components/main/Summary.vue
+++ b/apps/client/components/main/Summary.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <dialog
-      className="modal mt-[-8vh]"
+      className="modal mt-[-6vh]"
       :open="showModal"
     >
       <div className="modal-box max-w-[48rem]">


### PR DESCRIPTION
解决结算页面弹出后还可以点击上一题按钮的问题

<img width="1336" alt="image" src="https://github.com/cuixueshe/earthworm/assets/52577448/146d995a-fee2-4b8b-88d4-da65dfa55090">
