### PR TITLE
perf: animation slag on switch theme

### DIFF
--- a/apps/client/components/Home/CalendarGraph.vue
+++ b/apps/client/components/Home/CalendarGraph.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex justify-between">
-    <div class="main-info">
+  <div class="flex justify-between transition-all">
+    <div v-if="!loadingAnimation">
       <table class="border-spacing-1/2 border-separate text-xs">
         <thead>
           <th></th>
@@ -13,6 +13,7 @@
             {{ month }}
           </th>
         </thead>
+
         <tbody>
           <tr
             v-for="(row, i) in tbody"
@@ -21,18 +22,17 @@
             <td class="relative hidden w-8 md:block">
               <span class="absolute bottom-[-3px]">{{ i % 2 !== 0 ? weeks[i] : "" }}</span>
             </td>
+
             <td
               class="m-0"
               v-for="(cell, j) in row"
               :key="j"
             >
               <div
-                v-if="cell"
-                class="tooltip block"
-                :data-tip="cell.tips"
-              >
-                <div :class="`cell ${cell.bg}`"></div>
-              </div>
+                class="cell tooltip block"
+                :data-tip="cell?.tips"
+                :class="cell?.bg"
+              />
             </td>
           </tr>
         </tbody>
@@ -53,6 +53,12 @@
         </div>
       </div>
     </div>
+
+    <div
+      class="h-40 w-[800px] rounded-lg bg-black/20 blur-sm"
+      v-else
+    />
+
     <div class="dropdown dropdown-bottom ml-3 flex w-[120px]">
       <div
         tabindex="0"
@@ -81,10 +87,13 @@
 import { onMounted, watchEffect } from "vue";
 
 import type { CalendarData, EmitsType } from "~/composables/user/calendarGraph";
+import { useDarkMode } from "~/composables/darkMode";
 import { useCalendarGraph } from "~/composables/user/calendarGraph";
 
 const props = defineProps<{ data: CalendarData[]; totalCount: number }>();
 const emits = defineEmits<EmitsType>();
+
+const { loadingAnimation } = useDarkMode();
 
 const { initTable, renderBody, weeks, thead, tbody, year, yearOptions } = useCalendarGraph(emits);
 

--- a/apps/client/composables/darkMode.ts
+++ b/apps/client/composables/darkMode.ts
@@ -11,6 +11,8 @@ const DARK_THEME_CLASS = "dark";
 const LIGHT_THEME_CLASS = "light";
 
 const darkMode = ref(Theme.LIGHT);
+const loadingAnimation = ref(false);
+
 export function useDarkMode() {
   const isAppearanceTransition =
     // @ts-expect-error: Transition API
@@ -53,6 +55,7 @@ export function useDarkMode() {
     });
 
     transition.ready.then(() => {
+      loadingAnimation.value = true;
       const clipPath = [`circle(0px at ${x}px ${y}px)`, `circle(${endRadius}px at ${x}px ${y}px)`];
       document.documentElement.animate(
         {
@@ -64,6 +67,10 @@ export function useDarkMode() {
           pseudoElement: isDark ? "::view-transition-new(root)" : "::view-transition-old(root)",
         },
       );
+    });
+
+    transition.finished.then(() => {
+      loadingAnimation.value = false;
     });
   };
 
@@ -82,5 +89,6 @@ export function useDarkMode() {
     toggleDarkMode,
     initDarkMode,
     darkMode,
+    loadingAnimation,
   };
 }


### PR DESCRIPTION
用于优化打卡页面切换主题时的卡顿现象，主要优化的思路：
1. 添加一个参数用于判断主题切换动画何时开始，何时结束
2. 对于数量众多的小格子，在动画开始时就将其dom全部清除，在动画结束后进行重绘

目前，切换过程的遮罩不是很美观，可以考虑和`打卡图组件`深度结合，重构一版样式

PS: 放一个前后对比效果图

https://github.com/cuixueshe/earthworm/assets/48410934/ccb8ad02-85e9-46ae-8c0b-27e006164207


https://github.com/cuixueshe/earthworm/assets/48410934/ae996177-3b3b-44b1-bf22-be986fe9cc25

