### PR TITLE
style: optimize home page layout

### DIFF
--- a/apps/client/components/Home/RecentCoursePack.vue
+++ b/apps/client/components/Home/RecentCoursePack.vue
@@ -1,45 +1,41 @@
 <template>
-  <div class="border-1 w-full rounded-sm px-4 md:px-0">
+  <div class="flex min-h-80">
+    <!-- Loading -->
     <div
-      class="flex min-h-[350px] w-full flex-wrap items-center justify-center gap-4"
       v-if="isLoading"
+      class="flex flex-1 items-center justify-center"
     >
       <span class="loading loading-dots loading-md"></span>
     </div>
+
     <div
       v-else
-      class="flex flex-wrap gap-4"
+      class="grid w-full grid-cols-1 gap-4 min-[500px]:grid-cols-2 md:grid-cols-1 min-[850px]:grid-cols-2 xl:grid-cols-3"
     >
       <div
+        class="course-pack-card"
         v-for="coursePack in coursePacks"
-        :key="coursePack.id"
-        class="card flex w-72 shrink-0 flex-col gap-2 bg-base-100 shadow transition-shadow hover:shadow-lg"
       >
-        <figure>
-          <NuxtImg
+        <div class="h-40">
+          <img
+            class="h-full w-full bg-gray-200"
             :src="coursePack.cover"
-            :placeholder="[288, 180]"
-            width="288"
-            height="180"
           />
-        </figure>
-        <div class="mt-2 p-4">
-          <h2 class="card-title dark:text-white">{{ coursePack.title }}</h2>
-          <div class="max-h-30 mt-2 flex min-h-20 flex-grow flex-col truncate text-gray-400">
-            <span> 课程简介 </span>
-            <span class="text-[14px]">
-              {{ coursePack.description }}
-            </span>
-          </div>
-          <div class="flex items-center justify-between">
+        </div>
+        <div class="flex flex-1 flex-col p-4">
+          <h2 class="truncate text-lg font-semibold">{{ coursePack.title }}</h2>
+          <p class="mt-2 line-clamp-2 min-h-[3em] text-sm text-gray-500">
+            {{ coursePack.description }}
+          </p>
+          <div class="mt-auto flex justify-between">
             <button
-              class="btn btn-primary btn-sm border-none bg-[#1f6feb] text-white hover:bg-[#1f6feb]"
+              class="btn btn-sm tw-btn-blue"
               @click="handleGotoCourseList(coursePack.coursePackId)"
             >
               课程列表
             </button>
             <button
-              class="btn btn-primary btn-secondary btn-sm text-white"
+              class="btn btn-success btn-sm text-white"
               @click="handleContinueGame(coursePack.coursePackId, coursePack.courseId)"
             >
               继续游戏
@@ -81,3 +77,10 @@ function handleContinueGame(coursePackId: string, courseId: string) {
   navigateTo(`/game/${coursePackId}/${courseId}`);
 }
 </script>
+
+<style scoped>
+.course-pack-card {
+  @apply flex h-[350px] cursor-pointer flex-col overflow-hidden rounded-md rounded-t-xl border bg-white transition-all duration-300 dark:border-gray-700 dark:bg-gray-900;
+  @apply hover:text-purple-500 hover:shadow-even-lg hover:shadow-gray-300 hover:dark:text-purple-400 dark:hover:shadow-gray-500;
+}
+</style>

--- a/apps/client/components/Home/index.vue
+++ b/apps/client/components/Home/index.vue
@@ -1,71 +1,51 @@
 <template>
-  <div class="flex h-full w-full">
-    <div class="mr-10 hidden max-w-[230px] md:block">
-      <div class="md-4 flex flex-col md:mr-10">
-        <div
-          class="h-[230px] w-[230px] overflow-hidden rounded-full border border-gray-200 p-[2px] dark:border-gray-600"
-        >
-          <img
-            :src="userStore.userInfo?.picture!"
-            class="h-full w-full cursor-pointer"
-          />
-        </div>
-        <div class="mt-6 text-2xl font-bold">{{ userStore.userInfo?.username }}</div>
-        <div class="text-xl font-light text-gray-400">
-          {{ userStore.userInfo?.name }}
-        </div>
-        <!-- TODO: 等勋章功能上线后，再显示此区域-->
-        <!-- <div
-          class="border-t-solid border-t-black-200 mt-5 flex flex-col border-t border-gray-300 pt-5 dark:border-gray-700"
-        >
-          <div class="text-md">勋章</div>
-          <div class="mt-3 grid grid-cols-3 gap-2">
-            <div
-              class="m-auto flex-shrink-0 overflow-hidden rounded-full"
-              v-for="i in 12"
-              :key="i"
-            >
-              <img
-                src="https://sdfsdf.dev/72x72.png"
-                alt=""
-                class="flex-shrink-0"
-              />
-            </div>
-          </div>
-        </div> -->
-      </div>
-    </div>
-    <div
-      class="flex flex-1 flex-col justify-between rounded-md border border-gray-300 p-5 dark:border-gray-700"
-    >
-      <div class="top">
-        <div class="flex items-center">
-          <div class="mr-auto text-2xl font-bold">最近使用的课程包</div>
-          <NuxtLink
-            href="/course-pack"
-            class="btn btn-primary btn-sm mr-2 border-none bg-[#1f6feb] text-white hover:bg-[#1f6feb]"
-            >更多课程包</NuxtLink
-          >
-          <!-- <NuxtLink
-          class="btn btn-primary btn-sm"
-          href="/course-pack"
-          >更多音乐</NuxtLink
-        > -->
-        </div>
-        <HomeRecentCoursePack class="mt-3 md:mt-5" />
-      </div>
-      <div class="w-full rounded-xl">
-        <hr class="my-3 border-gray-300 dark:border-gray-700 md:my-5" />
-        <HomeCalendarGraph
-          :data="learnRecord.list"
-          :totalCount="learnRecord.totalCount"
-          @toggleYear="toggleYear"
+  <div class="mt-8 flex w-full justify-between">
+    <!-- 左侧头像区域 -->
+    <div class="mr-16 hidden w-72 md:block">
+      <div class="mx-auto h-56 w-56 overflow-hidden">
+        <img
+          class="h-full w-full rounded-full border-2 border-gray-300 bg-gray-200 dark:border-gray-700"
+          :src="userStore.userInfo?.picture!"
         />
       </div>
+      <div class="mt-4 truncate">
+        <div class="text-3xl font-medium">{{ userStore.userInfo?.username }}</div>
+        <div class="text-md text-gray-400">
+          {{ userStore.userInfo?.name || "未设置" }}
+        </div>
+      </div>
+      <hr class="my-5 dark:border-gray-700" />
+      <!-- TODO: 等后续勋章制作完成再放出来 -->
+      <!-- <div class="text-lg font-medium">勋章</div>
+      <div class="mt-2 grid grid-cols-4 gap-2">
+        <div
+          v-for="i in 6"
+          class="h-16 w-16 rounded-full bg-gray-200 dark:bg-gray-700"
+        ></div>
+      </div> -->
+    </div>
+
+    <!-- 右侧课程包区域 -->
+    <div class="flex-1">
+      <div class="mb-4 flex justify-between border-b pb-2 dark:border-gray-700">
+        <div class="text-xl font-medium">最近使用的课程包</div>
+        <NuxtLink
+          href="/course-pack"
+          class="link text-blue-500 no-underline hover:opacity-75"
+          >更多课程包
+        </NuxtLink>
+      </div>
+      <HomeRecentCoursePack />
+
+      <hr class="my-5 dark:border-gray-700" />
+      <HomeCalendarGraph
+        :data="learnRecord.list"
+        :totalCount="learnRecord.totalCount"
+        @toggleYear="toggleYear"
+      />
     </div>
   </div>
 </template>
-
 <script setup lang="ts">
 import { ref } from "vue";
 

--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -14,7 +14,7 @@
               <img
                 width="48"
                 height="48"
-                class="mr-6 hidden overflow-hidden rounded-md min-[800px]:block"
+                class="mr-6 hidden overflow-hidden rounded-md md:block"
                 src="/logo.png"
                 alt="earth-worm-logo"
               />
@@ -62,15 +62,16 @@
           <button
             v-else
             aria-label="Login"
-            class="btn btn-sm mr-1 border-none bg-purple-500 text-white shadow-md hover:bg-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-700"
+            class="btn btn-sm mr-1 border-none bg-purple-500 text-white shadow-md hover:bg-purple-600 focus:outline-none"
             @click="signIn()"
           >
             登录
           </button>
 
           <!-- 切换主题 -->
+          <!-- -mr-1 是为了和主体内容按钮/其他元素做右对齐 -->
           <button
-            class="btn btn-ghost btn-sm ml-1 h-8 w-8 rounded-md p-0"
+            class="btn btn-ghost btn-sm -mr-1 ml-1 h-8 w-8 rounded-md p-0"
             @click="toggleDarkMode"
           >
             <span

--- a/apps/client/pages/User/Setting.vue
+++ b/apps/client/pages/User/Setting.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mx-auto my-8 w-full min-w-max max-w-screen-lg space-y-8 rounded-xl bg-base-100 px-6 py-8 shadow-even-xl dark:shadow-purple-500/30 min-[800px]:px-12"
+    class="mx-auto my-8 w-full min-w-max max-w-screen-lg space-y-8 rounded-xl bg-base-100 px-6 py-8 shadow-even-xl dark:shadow-purple-500/30 md:px-12"
   >
     <section>
       <h2 class="text-xl font-medium">游戏模式</h2>

--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -56,5 +56,19 @@ export default {
       // 来这里找 https://icones.js.org/
       collections: getIconCollections(["ph", "simple-icons"]),
     }),
+    function ({ addComponents }) {
+      const buttons = {
+        ".tw-btn-blue": {
+          backgroundColor: "#4e80ee",
+          color: "#fff",
+          border: "none",
+          "&:hover": {
+            backgroundColor: "#3662e3",
+          },
+        },
+      };
+
+      addComponents(buttons);
+    },
   ],
 };


### PR DESCRIPTION
## 优化首页布局 ✅

- 对齐右侧按钮（顶部导航栏 / 更多课程包 / 2024） ✅
  - 将 Navbar 最后一个 icon 向右移动一点
  - 保证主体内容区域不变
- 填充头像圆角切割的空隙 ✅
- 去掉课程包的边框（不好看）✅
- 重写卡片布局样式（不用 daisyUI）✅
- 缩小整体卡片 ✅
- 添加图片默认底色 ✅
- 设置卡片固定高度
- 标题单行省略号 ✅
- 描述双行省略号 ✅
- 设置描述区域最低高度 ✅
- 响应式适配 ✅
- 响应式动画过渡 ✅
- 增加鼠标悬停缩放动画 ✅
- 调整卡片内按钮颜色（不协调）✅
- 调整标题、描述字体大小以及颜色暗黑主题适配（边框和背景）✅

> 之前

![image](https://github.com/cuixueshe/earthworm/assets/48991003/39e1b9e1-f7a1-4539-97b4-62d7eb9561f9)

![image](https://github.com/cuixueshe/earthworm/assets/48991003/4b106f10-d5c0-4337-b890-2921b94dd2dd)

> 现在

![image](https://github.com/cuixueshe/earthworm/assets/48991003/3c688635-ec4f-4f31-a994-1b2246a8ab90)

> 暗黑主题显示

![image](https://github.com/cuixueshe/earthworm/assets/48991003/90e897bc-7543-4c40-965b-f595d4c45691)
