### PR TITLE
chore: add picocolors modules & delete useless log

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "conventional-changelog-cli": "^4.1.0",
     "dotenv": "^16.3.1",
     "lint-staged": "^15.2.2",
+    "picocolors": "^1.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "0.5.13",
     "simple-git-hooks": "2.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.2
+      picocolors:
+        specifier: ^1.0.1
+        version: 1.0.1
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -5873,6 +5876,9 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
+  picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -7796,7 +7802,7 @@ snapshots:
   '@babel/code-frame@7.24.2':
     dependencies:
       '@babel/highlight': 7.24.2
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/compat-data@7.23.5': {}
 
@@ -7974,7 +7980,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/parser@7.23.6':
     dependencies:
@@ -14211,6 +14217,8 @@ snapshots:
 
   picocolors@1.0.0: {}
 
+  picocolors@1.0.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@3.0.1: {}
@@ -15696,7 +15704,7 @@ snapshots:
     dependencies:
       browserslist: 4.22.3
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   uqr@0.1.2: {}
 

--- a/scripts/verify-commit.ts
+++ b/scripts/verify-commit.ts
@@ -10,9 +10,9 @@ const commitRE =
   /^(revert: )?(feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(\(.+\))?: .{1,50}/;
 
 if (!commitRE.test(msg)) {
-  console.log();
   console.error(
-    `  ${pico.white(pico.bgRed(" ERROR "))} ${pico.red(`invalid commit message format.`)}\n\n` +
+    `
+  ${pico.white(pico.bgRed(" ERROR "))} ${pico.red(`invalid commit message format.`)}\n\n` +
       pico.red(
         `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
       ) +


### PR DESCRIPTION
1. 引用picocolors包，虽然在vite库中有关于该包的引用，但是最好还是把该引用放到自己的项目中更安全，且lint检测会报红。
3. 删除无用的console.log. 使用 模版字符串``可以实现换行效果，没必要为了换行而专门使用一个log.