### PR TITLE
fix: about `z-index` level display

### DIFF
--- a/apps/client/components/DropMenu.vue
+++ b/apps/client/components/DropMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="dropdown dropdown-end z-[35] h-8 w-8"
+    class="dropdown dropdown-end h-8 w-8"
     @click="toggleDropdown"
   >
     <button
@@ -13,7 +13,7 @@
       v-if="showDropdown"
       ref="dropdownContainer"
       tabindex="0"
-      class="menu dropdown-content z-[40] mt-2 w-52 rounded-md border-2 border-gray-200 bg-white p-2 dark:border-gray-600 dark:bg-theme-dark"
+      class="menu dropdown-content z-[1] mt-2 w-52 rounded-md border-2 border-gray-200 bg-white p-2 dark:border-gray-600 dark:bg-theme-dark"
     >
       <li
         v-for="(item, index) in showMenuOptions"

--- a/apps/client/components/Navbar.vue
+++ b/apps/client/components/Navbar.vue
@@ -2,8 +2,9 @@
   <header
     class="w-full px-5 font-customFont transition-all duration-300 ease-linear"
     :class="{
-      'sticky top-0 z-20': isStickyNavBar,
-      'glass bg-gradient-to-r from-transparent via-white/10 to-transparent shadow-md': isScrolled,
+      'sticky top-0 z-10': isStickyNavBar,
+      'glass bg-gradient-to-r from-transparent via-white/10 to-transparent shadow-md':
+        isStickyNavBar && isScrolled,
     }"
   >
     <div class="mx-auto max-w-screen-xl">

--- a/apps/client/components/main/Contents/Contents.vue
+++ b/apps/client/components/main/Contents/Contents.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="contents"
-    class="absolute left-0 top-20 z-20 w-80 select-none overflow-x-hidden border-l-4 border-fuchsia-500 bg-white shadow dark:bg-slate-800"
+    class="absolute left-0 top-20 z-10 w-80 select-none overflow-x-hidden border-l-4 border-fuchsia-500 bg-white shadow dark:bg-slate-800"
     :class="[isShowContents() && 'show']"
     v-bind="containerProps"
   >

--- a/apps/client/components/main/Tool.vue
+++ b/apps/client/components/main/Tool.vue
@@ -6,13 +6,13 @@
     <div class="flex items-center">
       <NuxtLink
         :href="`/course-pack/${courseStore.currentCourse?.coursePackId}`"
-        class="clickable-item tooltip-item"
+        class="clickable-item tooltip"
         data-tip="课程列表"
       >
         <IconsExpand class="h-7 w-7" />
       </NuxtLink>
       <div
-        class="clickable-item tooltip-item ml-4"
+        class="clickable-item tooltip ml-4"
         data-tip="课程题目列表"
         @click="toggleContents"
       >
@@ -27,14 +27,14 @@
     <!-- 右侧 -->
     <div class="flex items-center">
       <div
-        class="tooltip-item mr-4"
+        class="tooltip mr-4"
         data-tip="重置当前课程进度"
         @click="handleDoAgain"
       >
         <span class="clickable-item icon-item i-ph-arrow-counter-clockwise"></span>
       </div>
       <div
-        class="tooltip-item mr-1"
+        class="tooltip mr-1"
         data-tip="排行榜"
         @click="rankingStore.showRankModal"
       >
@@ -117,10 +117,6 @@ function useDoAgain() {
 </script>
 
 <style scoped>
-.tooltip-item {
-  @apply tooltip z-20;
-}
-
 .clickable-item {
   @apply cursor-pointer select-none hover:text-fuchsia-500;
 }


### PR DESCRIPTION
related to #670

## 将部分页面设置的 `z-20` 降级到 `z-10`

全局检索了下，z-20 的和 z-10 的几个页面显示也不冲突，那就从最低的 10 开始就行

![1715886388307](https://github.com/cuixueshe/earthworm/assets/48991003/4fde2d32-2330-4b54-a9d4-96ad0bc27159)

## 去掉一些 `z-index`

之前我给 Tool 工具栏加 z-index 就是为了适配 Navbar 栏设置的 z-index，这里也是因为 tooltip 的原因，会被挡在下面，如图

![image](https://github.com/cuixueshe/earthworm/assets/48991003/8497721d-6918-434c-b1df-59b33aef92c5)

后面添加 Navbar 栏底部横线动画时发现没必要一直给 Navbar 栏 z-index，只需要判断页面是否需要固定定位来添加就行

![image](https://github.com/cuixueshe/earthworm/assets/48991003/80487051-ca7e-495b-9676-fb843a873ddc)

所以之前给 Tool 工具栏设置的 z-index 都可以删掉了，在游戏页面中是不需要固定定位 Navbar 的，也就是压根就没有 z-index，我们遵循默认的文档流层级设置就好

**额外提一嘴**：z-index 在不得已的情况下不要随心来添加设置，这里给 z-20 这里给 z-40 什么的，很容易让人看的一脸懵，在后续出现层级关系调整的时候也很乱，对了，还有一个小提示 “子元素的 z-index 再大也不可能超过父元素”

之前在设置 `z-index` 的时候没有注意这个问题，导致一直在坑里找问题，后面调试页面 DOM 一看突然发现父元素设置了 `z-20`（header），子元素想设置 `z-30`（ul）已经是不可能的，自然就不生效了，如图

![image](https://github.com/cuixueshe/earthworm/assets/48991003/521b406e-ab13-4540-a1ee-916b23b4f2b1)

顺便修复下在游戏页滚动会给 Navbar 添加底部阴影的问题

![image](https://github.com/cuixueshe/earthworm/assets/48991003/a77af4a0-19f8-4390-b0e4-2a3ab182d71d)
