### PR TITLE
style: optimize calendar graph responsive layout

### DIFF
--- a/apps/client/assets/css/globals.css
+++ b/apps/client/assets/css/globals.css
@@ -111,6 +111,7 @@ body {
 
 ::-webkit-scrollbar {
   width: 7px;
+  height: 7px;
 }
 
 ::-webkit-scrollbar-track {

--- a/apps/client/components/Home/CalendarGraph.vue
+++ b/apps/client/components/Home/CalendarGraph.vue
@@ -1,78 +1,72 @@
 <template>
   <div class="flex justify-between">
-    <div class="main-info">
-      <table class="border-spacing-1/2 border-separate text-xs">
-        <thead>
-          <th></th>
-          <th
-            :colspan="colSpan"
-            v-for="{ colSpan, month } in thead"
-            :key="month"
-            class="text-left font-normal"
-          >
-            {{ month }}
-          </th>
-        </thead>
-        <tbody>
-          <tr
-            v-for="(row, i) in tbody"
-            :key="weeks[i]"
-          >
-            <td class="relative hidden w-8 md:block">
-              <span class="absolute bottom-[-3px]">{{ i % 2 !== 0 ? weeks[i] : "" }}</span>
-            </td>
-            <td
-              class="m-0"
-              v-for="(cell, j) in row"
-              :key="j"
+    <!-- 左侧打卡图 -->
+    <div
+      class="min-w-0 flex-1 rounded-md border border-gray-300 px-2 py-4 text-xs dark:border-gray-700"
+    >
+      <div class="w-full overflow-x-auto">
+        <table class="mx-auto overflow-hidden">
+          <thead>
+            <th></th>
+            <th
+              :colspan="colSpan"
+              v-for="{ colSpan, month } in thead"
+              :key="month"
+              class="text-left font-normal"
             >
-              <div
-                v-if="cell"
-                class="tooltip block"
-                :data-tip="cell.tips"
+              {{ month }}
+            </th>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, i) in tbody"
+              :key="weeksZh[i]"
+            >
+              <td class="relative hidden w-8 md:block">
+                <span class="absolute">{{ i % 2 !== 0 ? weeksZh[i] : "" }}</span>
+              </td>
+              <td
+                class="m-0"
+                v-for="(cell, j) in row"
+                :key="j"
               >
-                <div :class="`cell ${cell.bg}`"></div>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                <div
+                  v-if="cell"
+                  class="tooltip block"
+                  :data-tip="cell.tips"
+                >
+                  <div :class="`cell ${cell.bg}`"></div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-      <div class="flex justify-between px-4 py-2">
-        <span class="justify-self-end pl-2 text-sm dark:text-gray-400">
-          一共学习了 {{ totalCount }} 次</span
+      <div class="mt-2 flex justify-between px-1">
+        <span class="justify-self-end text-sm dark:text-gray-400">
+          一共学习了 <span class="font-semibold">{{ totalCount }}</span> 次</span
         >
         <div class="flex items-center gap-1 text-xs">
-          <div class="text-gray-500">Less</div>
+          <div class="text-gray-500">更少</div>
           <div class="cell"></div>
           <div class="cell low"></div>
           <div class="cell moderate"></div>
           <div class="cell high"></div>
           <div class="cell higher"></div>
-          <div class="text-gray-500">More</div>
+          <div class="text-gray-500">更多</div>
         </div>
       </div>
     </div>
-    <div class="dropdown dropdown-bottom ml-3 flex w-[120px]">
-      <div
-        tabindex="0"
-        class="h-fit w-full cursor-pointer rounded-md bg-[#1f6feb] p-2 text-sm text-white"
-      >
-        {{ year || yearOptions[0].label }}
-      </div>
-      <!-- TODO: 暂时只有 2024 年一年的数据 所以先不需要展开了 -->
-      <!-- <ul
-          tabindex="0"
-          class="menu dropdown-content z-[1] w-52 rounded-box bg-base-100 p-2 shadow"
-        >
-          <li
-            v-for="item in yearOptions"
-            :key="item.value"
-            @click="initTable(item.value)"
-          >
-            <a>{{ item.label }}</a>
-          </li>
-        </ul> -->
+
+    <!-- 右侧年份选项 -->
+    <!-- TODO: 多年份选择还没做，目前只有 2024，先写死了 -->
+    <div
+      class="btn btn-sm tw-btn-blue ml-6 hidden pr-7 xl:flex"
+      v-for="year in yearOptions"
+      :key="year.value"
+    >
+      {{ year.label }}
     </div>
   </div>
 </template>
@@ -86,7 +80,7 @@ import { useCalendarGraph } from "~/composables/user/calendarGraph";
 const props = defineProps<{ data: CalendarData[]; totalCount: number }>();
 const emits = defineEmits<EmitsType>();
 
-const { initTable, renderBody, weeks, thead, tbody, year, yearOptions } = useCalendarGraph(emits);
+const { initTable, renderBody, thead, tbody, weeksZh, yearOptions } = useCalendarGraph(emits);
 
 onMounted(() => {
   initTable();
@@ -99,7 +93,7 @@ watchEffect(() => {
 
 <style scoped>
 .cell {
-  @apply h-[11px] w-[11px] rounded-sm bg-[#ebedf0] dark:bg-[#2d333b];
+  @apply mt-[2px] h-[12px] w-[12px] rounded-sm bg-[#ebedf0] dark:bg-[#2d333b];
 }
 
 .low {

--- a/apps/client/components/Home/RecentCoursePack.vue
+++ b/apps/client/components/Home/RecentCoursePack.vue
@@ -16,18 +16,16 @@
         class="course-pack-card"
         v-for="coursePack in coursePacks"
       >
-        <div class="h-40">
-          <img
-            class="h-full w-full bg-gray-200"
-            :src="coursePack.cover"
-          />
-        </div>
+        <img
+          class="min-h-44 w-full bg-gray-300 object-cover dark:bg-gray-700"
+          :src="coursePack.cover"
+        />
         <div class="flex flex-1 flex-col p-4">
           <h2 class="truncate text-lg font-semibold">{{ coursePack.title }}</h2>
-          <p class="mt-2 line-clamp-2 min-h-[3em] text-sm text-gray-500">
+          <p class="my-2 line-clamp-2 min-h-[3em] text-sm text-gray-500">
             {{ coursePack.description }}
           </p>
-          <div class="mt-auto flex justify-between">
+          <div class="flex justify-between">
             <button
               class="btn btn-sm tw-btn-blue"
               @click="handleGotoCourseList(coursePack.coursePackId)"
@@ -80,7 +78,7 @@ function handleContinueGame(coursePackId: string, courseId: string) {
 
 <style scoped>
 .course-pack-card {
-  @apply flex h-[350px] cursor-pointer flex-col overflow-hidden rounded-md rounded-t-xl border bg-white transition-all duration-300 dark:border-gray-700 dark:bg-gray-900;
+  @apply flex cursor-pointer flex-col overflow-hidden rounded-md rounded-t-xl border bg-white transition-all duration-300 dark:border-gray-700 dark:bg-gray-900;
   @apply hover:text-purple-500 hover:shadow-even-lg hover:shadow-gray-300 hover:dark:text-purple-400 dark:hover:shadow-gray-500;
 }
 </style>

--- a/apps/client/components/Home/index.vue
+++ b/apps/client/components/Home/index.vue
@@ -4,7 +4,7 @@
     <div class="mr-16 hidden w-72 md:block">
       <div class="mx-auto h-56 w-56 overflow-hidden">
         <img
-          class="h-full w-full rounded-full border-2 border-gray-300 bg-gray-200 dark:border-gray-700"
+          class="h-full w-full rounded-full border-2 border-gray-300 bg-gray-300 object-cover dark:border-gray-700 dark:bg-gray-700"
           :src="userStore.userInfo?.picture!"
         />
       </div>
@@ -26,7 +26,7 @@
     </div>
 
     <!-- 右侧课程包区域 -->
-    <div class="flex-1">
+    <div class="min-w-0 flex-1">
       <div class="mb-4 flex justify-between border-b pb-2 dark:border-gray-700">
         <div class="text-xl font-medium">最近使用的课程包</div>
         <NuxtLink
@@ -36,9 +36,8 @@
         </NuxtLink>
       </div>
       <HomeRecentCoursePack />
-
-      <hr class="my-5 dark:border-gray-700" />
       <HomeCalendarGraph
+        class="mt-10"
         :data="learnRecord.list"
         :totalCount="learnRecord.totalCount"
         @toggleYear="toggleYear"

--- a/apps/client/composables/user/calendarGraph.ts
+++ b/apps/client/composables/user/calendarGraph.ts
@@ -9,6 +9,15 @@ const weeks: Record<number, string> = {
   5: "Fri",
   6: "Sat",
 };
+const weeksZh: Record<number, string> = {
+  0: "周日",
+  1: "周一",
+  2: "周二",
+  3: "周三",
+  4: "周四",
+  5: "周五",
+  6: "周六",
+};
 const months: Record<number, string> = {
   0: "January",
   1: "February",
@@ -22,6 +31,20 @@ const months: Record<number, string> = {
   9: "October",
   10: "November",
   11: "December",
+};
+const monthsZh: Record<number, string> = {
+  0: "一月",
+  1: "二月",
+  2: "三月",
+  3: "四月",
+  4: "五月",
+  5: "六月",
+  6: "七月",
+  7: "八月",
+  8: "九月",
+  9: "十月",
+  10: "十一月",
+  11: "十二月",
 };
 
 export interface EmitsType {
@@ -54,6 +77,8 @@ const thead = ref<TableHead[]>([]);
 const tbody = ref<(null | TableBody)[][]>([]);
 
 export function useCalendarGraph(emits: EmitsType) {
+  getOptions();
+
   /**
    * format date
    * @param date date
@@ -64,11 +89,12 @@ export function useCalendarGraph(emits: EmitsType) {
   }
 
   function getOptions() {
+    // 重置列表，避免点击其他页面回来的时候录入重复的年份数据
+    yearOptions.value = [];
     for (let i = 2024; i <= new Date().getFullYear(); i++) {
       yearOptions.value.unshift({ label: i.toString(), value: i });
     }
   }
-  getOptions();
 
   function getOrdinalSuffix(day: number) {
     const lastTwoDigits = day % 100;
@@ -77,6 +103,7 @@ export function useCalendarGraph(emits: EmitsType) {
     if ([1, 2, 3].includes(lastDigit)) return { 1: "st", 2: "nd", 3: "rd" }[lastDigit] as string;
     return "th";
   }
+
   function getActivityLevel(count?: number) {
     if (!count) return "";
     if (count < 3) return "low";
@@ -84,21 +111,22 @@ export function useCalendarGraph(emits: EmitsType) {
     if (count < 10) return "high";
     return "higher";
   }
+
   function renderBody(list: CalendarData[]) {
     return tbody.value.map((row) => {
       return row.map((item) => {
         if (!item) return null;
         const year = item.date.getFullYear();
-        const month = item.date.getMonth();
-        const day = item.date.getDate();
+        const month = String(item.date.getMonth() + 1).padStart(2, "0");
+        const day = String(item.date.getDate()).padStart(2, "0");
         const date = format(item.date);
         const current = list.find((f) => {
           return f.day === date;
         });
 
-        const tipText = current?.count ? `学习了 ${current?.count} 次 ` : `没有学习`;
+        const tipText = current?.count ? `${current?.count}次学习` : `没有学习`;
+        const tips = `${tipText}, ${year}-${month}-${day}`;
 
-        const tips = `${tipText} ${months[month]} ${day}${getOrdinalSuffix(day)}, ${year}`;
         return { date: item.date, tips, bg: getActivityLevel(current?.count) };
       });
     });
@@ -108,7 +136,7 @@ export function useCalendarGraph(emits: EmitsType) {
     return thead.map((item, i) => {
       const nextItem = thead[i + 1] || { offset: 53 };
       const colSpan = nextItem.offset - item.offset;
-      const month = months[item.month]?.slice(0, 3);
+      const month = monthsZh[item.month]?.slice(0, 3);
       return { colSpan, month };
     });
   }
@@ -195,6 +223,7 @@ export function useCalendarGraph(emits: EmitsType) {
     renderHead,
     renderBody,
     weeks,
+    weeksZh,
     thead,
     tbody,
     year,

--- a/apps/client/composables/user/tests/calendarGraph.spec.ts
+++ b/apps/client/composables/user/tests/calendarGraph.spec.ts
@@ -114,18 +114,18 @@ describe("use calendar graph", () => {
     const data = renderHead(thead);
 
     expect(data).toEqual([
-      { colSpan: 5, month: "Jan" },
-      { colSpan: 4, month: "Feb" },
-      { colSpan: 5, month: "Mar" },
-      { colSpan: 4, month: "Apr" },
-      { colSpan: 4, month: "May" },
-      { colSpan: 5, month: "Jun" },
-      { colSpan: 4, month: "Jul" },
-      { colSpan: 4, month: "Aug" },
-      { colSpan: 5, month: "Sep" },
-      { colSpan: 4, month: "Oct" },
-      { colSpan: 4, month: "Nov" },
-      { colSpan: 5, month: "Dec" },
+      { colSpan: 5, month: "一月" },
+      { colSpan: 4, month: "二月" },
+      { colSpan: 5, month: "三月" },
+      { colSpan: 4, month: "四月" },
+      { colSpan: 4, month: "五月" },
+      { colSpan: 5, month: "六月" },
+      { colSpan: 4, month: "七月" },
+      { colSpan: 4, month: "八月" },
+      { colSpan: 5, month: "九月" },
+      { colSpan: 4, month: "十月" },
+      { colSpan: 4, month: "十一月" },
+      { colSpan: 5, month: "十二月" },
     ]);
   });
 
@@ -140,13 +140,13 @@ describe("use calendar graph", () => {
 
     const tbody = renderBody(apiData);
 
-    expect(tbody[1][0]?.tips).toBe("学习了 1 次  January 1st, 2024");
+    expect(tbody[1][0]?.tips).toBe("1次学习, 2024-01-01");
     expect(tbody[1][0]?.bg).toBe("low");
-    expect(tbody[2][0]?.tips).toBe("学习了 3 次  January 2nd, 2024");
+    expect(tbody[2][0]?.tips).toBe("3次学习, 2024-01-02");
     expect(tbody[2][0]?.bg).toBe("moderate");
-    expect(tbody[3][0]?.tips).toBe("学习了 5 次  January 3rd, 2024");
+    expect(tbody[3][0]?.tips).toBe("5次学习, 2024-01-03");
     expect(tbody[3][0]?.bg).toBe("high");
-    expect(tbody[4][0]?.tips).toBe("学习了 10 次  January 4th, 2024");
+    expect(tbody[4][0]?.tips).toBe("10次学习, 2024-01-04");
     expect(tbody[4][0]?.bg).toBe("higher");
   });
 });

--- a/apps/client/pages/User/Setting.vue
+++ b/apps/client/pages/User/Setting.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mx-auto my-8 w-full min-w-max max-w-screen-lg space-y-8 rounded-xl bg-base-100 px-6 py-8 shadow-even-xl dark:shadow-purple-500/30 md:px-12"
+    class="mx-auto my-8 w-full min-w-max max-w-screen-lg space-y-8 rounded-xl bg-base-100 px-6 py-8 shadow-even-xl dark:bg-gray-900 dark:shadow-purple-500/30 md:px-12"
   >
     <section>
       <h2 class="text-xl font-medium">游戏模式</h2>


### PR DESCRIPTION
## 课程包 banner 图片显示方案 ✅

- 设置最低高度以及默认背景色（图片加载过程中占位显示）
- 不固定高度 + 宽度根据 grid 布局占满
- 设置图片根据比例显示填充（超出部分裁剪隐藏）

## 优化打卡图显示 ✅

- 响应式优化：在缩放时保持内部大小不变，外层盒子出现横向滚动条，而不是固定占位大小
- 更改为中文提示（月份 / 星期 / 悬停提示文本）
- 年份从底部左侧移动到右侧（小屏时隐藏保证打卡图的显示完整性）
- 设置默认滚动条高度

> 之前

![image](https://github.com/cuixueshe/earthworm/assets/48991003/973ef91d-fcc3-4b14-acf1-b725abbc76c7)

> 现在

![image](https://github.com/cuixueshe/earthworm/assets/48991003/86102e6b-021c-46a5-bc89-171a757982bc)

![image](https://github.com/cuixueshe/earthworm/assets/48991003/d13ab487-0348-4f6a-9e51-128fafcb44b5)

> 滚动条显示

![image](https://github.com/cuixueshe/earthworm/assets/48991003/36ca9bd7-73f8-4158-bb2b-a2bb0caf315f)