### PR TITLE
fix: confetti overlay

### DIFF
--- a/apps/client/components/main/Summary.vue
+++ b/apps/client/components/main/Summary.vue
@@ -61,12 +61,12 @@
         <kbd class="kbd"> ↵ </kbd>
       </button>
     </div>
-
-    <canvas
-      ref="confettiCanvasRef"
-      class="pointer-events-none absolute left-0 top-0 h-full w-full"
-    ></canvas>
   </CommonModal>
+
+  <canvas
+    ref="confettiCanvasRef"
+    class="pointer-events-none absolute left-0 top-0 z-[1000] h-full w-full"
+  ></canvas>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
如图，礼花的位置没有从页面最顶层开始播放

![image](https://github.com/cuixueshe/earthworm/assets/48991003/a3d13bb8-548b-417e-86d7-26558981797a)

出现问题的原因是当前绘制礼花的 `canvas` 定位是基于 `modal-box` 层（之前是基于 `dialog`）导致整体绘制的大小位置发生了变更

![image](https://github.com/cuixueshe/earthworm/assets/48991003/81f04e44-ed5b-4211-8d5a-d601289baebe)

> 这是之前的礼花 canvas 位置和大小

![image](https://github.com/cuixueshe/earthworm/assets/48991003/ce33bcd2-12e5-42c4-ac59-82c7636532f8)

既然如此，那就尝试将礼花的绘制 `canvas` 的放到外面

![image](https://github.com/cuixueshe/earthworm/assets/48991003/47cfbe5f-af17-4bcb-bd40-ec31c2c5b9e2)

很快我们发现了一个新的问题，因为 `dialog` 的 `modal` 类的 `z-index` 值是 **999**，所以如果我们的 `canvas` 不在 `modal` 内的话，播放礼花就只能在背后显示了，大部分会被 `modal-box` 实际显示的内容所遮盖

![image](https://github.com/cuixueshe/earthworm/assets/48991003/5d3fa001-896d-4d5d-8063-1cf18dba8ba9)

![image](https://github.com/cuixueshe/earthworm/assets/48991003/fde6a4b6-c6e5-4a79-b152-d746a4ddef54)

对此，有两个解决方案

1. 去掉手动 `canvas` 绘制，直接使用 `confetti` 方法播放礼花，配置其参数 `z-index` 高于 `modal`
2. 保持手动 `canvas` 绘制不变，在 `canvas` 上配置 `z-index` 高于 `modal`

为了不引起其他不必要的问题，这里选择第二种解决方案 😊