### PR TITLE
style: fix page element shake after loading

### DIFF
--- a/apps/client/components/Home/RecentCoursePack.vue
+++ b/apps/client/components/Home/RecentCoursePack.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex min-h-80">
+  <div class="flex min-h-[350px]">
     <!-- Loading -->
     <div
       v-if="isLoading"


### PR DESCRIPTION
## 问题

课程首页——课程包列表加载前后，打卡图在页面的位置出现轻微抖动

![录制于 2024-05-30 11 24 12](https://github.com/cuixueshe/earthworm/assets/48410934/d0420e73-49fe-47b0-b35e-3f8b9eec351e)

## 原因

课程包列表 `loading` 状态下的最小高度 `min-h-80` 无法包含课程包卡片加载后的高度

![image](https://github.com/cuixueshe/earthworm/assets/48410934/e04f2913-f928-4dc9-afd1-1d8eb6e105fc)

## 解决

增加课程包的最小高度到 `min-h-[350px]`

保证加载中和加载后显示的高度一致，避免 **高度闪烁** 问题