### PR TITLE
fix(client): website favicon path error

### DIFF
--- a/apps/client/nuxt.config.ts
+++ b/apps/client/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
   app: {
     head: {
       title: "Earthworm",
-      link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
+      link: [{ rel: "icon", type: "image/x-icon", href: "/logo.png" }],
       script: appScripts,
     },
   },

--- a/apps/client/nuxt.config.ts
+++ b/apps/client/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
   app: {
     head: {
       title: "Earthworm",
-      link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.png" }],
+      link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
       script: appScripts,
     },
   },


### PR DESCRIPTION
- Fix website favicon path error
	-	Before：
		<img width="189" alt="e8a1d50792ac625f57df18036620f1d" src="https://github.com/cuixueshe/earthworm/assets/88535417/fe8d5c88-134a-4c29-85d2-ac3075a1126a">
	
	-	Now:
		<img width="189" alt="e8a1d50792ac625f57df18036620f1d" src="https://github.com/cuixueshe/earthworm/assets/88535417/86b6b6e3-f49f-4c9c-aa5d-bdda5f7c5818">

