### PR TITLE
fix: card-between-without-gap

### DIFF
--- a/apps/client/components/courses/CoursePackCard.vue
+++ b/apps/client/components/courses/CoursePackCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="card w-72 shrink-0 cursor-pointer bg-base-100 shadow-xl"
+    class="card max-w-72 shrink-0 cursor-pointer bg-base-100 shadow-xl"
     @click="handleGoToCoursePack(coursePack)"
   >
     <figure>


### PR DESCRIPTION
在小屏幕下card的间距出现无法适配的情况（大概在768px-933px）
<img width="972" alt="image" src="https://github.com/cuixueshe/earthworm/assets/6906169/6e4210d4-a08c-42f0-be9c-1952baf2417a">


做了一个微小的工作：
1、card 的宽度 从固定宽度width改为 最大max-width.

使得卡片可以在屏幕大小在768px-933px之间可以自动缩小卡片保持间距
修改后：
<img width="1187" alt="image" src="https://github.com/cuixueshe/earthworm/assets/6906169/84771926-f95f-4ad8-9cb6-7b5bb99bc0b8">


