### PR TITLE
fix: center cards in course-pack page under narrow screen size 

### DIFF
--- a/apps/client/pages/course-pack/index.vue
+++ b/apps/client/pages/course-pack/index.vue
@@ -5,7 +5,9 @@
       <Loading></Loading>
     </template>
     <template v-else>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      <div
+        class="grid grid-cols-1 justify-items-center gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+      >
         <template v-for="coursePack in coursePackStore.coursePacks">
           <CoursePackCard :coursePack="coursePack"></CoursePackCard>
         </template>


### PR DESCRIPTION
I centered the cards' horizontal position by adding tailwind css class.
this is related with issue #716. 

What it looks like now

<img width="578" alt="截屏2024-06-15 18 50 40" src="https://github.com/cuixueshe/earthworm/assets/79150294/a3c73549-a3bc-4c54-9510-a21535aa8970">
