### PR TITLE
chore: add pointer for course-card

### DIFF
--- a/apps/client/components/courses/CourseCard.vue
+++ b/apps/client/components/courses/CourseCard.vue
@@ -57,7 +57,7 @@ onMounted(() => {
 
 <style scoped>
 .course-card {
-  @apply relative h-[160px] w-full rounded-xl border border-gray-400 p-4 pb-6 transition-all duration-300 dark:text-gray-100;
+  @apply relative h-[160px] w-full cursor-pointer rounded-xl border border-gray-400 p-4 pb-6 transition-all duration-300 dark:text-gray-100;
   @apply hover:text-purple-500 hover:shadow-lg hover:shadow-gray-300 hover:dark:text-purple-400 dark:hover:shadow-gray-500;
 }
 


### PR DESCRIPTION
For better user experience, we should add pointer to the area where can be clicked by user,
### Befor:
<img width="235" alt="image" src="https://github.com/cuixueshe/earthworm/assets/25007230/37a03351-8759-49c0-8acf-0e86a5a89bd7">

### After:
<img width="284" alt="image" src="https://github.com/cuixueshe/earthworm/assets/25007230/8962169d-04a1-4ac5-8f0a-d42253b11c8f">

